### PR TITLE
Fix presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+elm-stuff

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -5225,6 +5225,41 @@ var $author$project$Main$FormField = F5(
 	function (label, name, presence, description, type_) {
 		return {description: description, label: label, name: name, presence: presence, type_: type_};
 	});
+var $elm$json$Json$Decode$field = _Json_decodeField;
+var $elm$json$Json$Decode$at = F2(
+	function (fields, decoder) {
+		return A3($elm$core$List$foldr, $elm$json$Json$Decode$field, decoder, fields);
+	});
+var $elm$json$Json$Decode$oneOf = _Json_oneOf;
+var $elm$json$Json$Decode$string = _Json_decodeString;
+var $author$project$Main$decodeFormFieldDescription = $elm$json$Json$Decode$oneOf(
+	_List_fromArray(
+		[
+			A2(
+			$elm$json$Json$Decode$at,
+			_List_fromArray(
+				['presence', 'description']),
+			$elm$json$Json$Decode$string),
+			A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
+			$elm$json$Json$Decode$succeed('')
+		]));
+var $author$project$Main$decodeFormFieldMaybeName = $elm$json$Json$Decode$oneOf(
+	_List_fromArray(
+		[
+			A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$Just,
+			A2(
+				$elm$json$Json$Decode$at,
+				_List_fromArray(
+					['presence', 'name']),
+				$elm$json$Json$Decode$string)),
+			A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$Just,
+			A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string)),
+			$elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing)
+		]));
 var $author$project$Main$ChooseMultiple = function (a) {
 	return {$: 'ChooseMultiple', a: a};
 };
@@ -5268,14 +5303,11 @@ var $author$project$Main$choiceFromString = function (s) {
 		return {label: s, value: s};
 	}
 };
-var $elm$json$Json$Decode$string = _Json_decodeString;
 var $author$project$Main$decodeChoice = A2($elm$json$Json$Decode$map, $author$project$Main$choiceFromString, $elm$json$Json$Decode$string);
 var $elm$json$Json$Decode$fail = _Json_fail;
-var $elm$json$Json$Decode$field = _Json_decodeField;
 var $elm$json$Json$Decode$int = _Json_decodeInt;
 var $elm$json$Json$Decode$list = _Json_decodeList;
 var $elm$json$Json$Decode$null = _Json_decodeNull;
-var $elm$json$Json$Decode$oneOf = _Json_oneOf;
 var $elm$json$Json$Decode$nullable = function (decoder) {
 	return $elm$json$Json$Decode$oneOf(
 		_List_fromArray(
@@ -5374,58 +5406,18 @@ var $author$project$Main$decodePresence = $elm$json$Json$Decode$oneOf(
 			},
 			A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string))
 		]));
-var $elm$core$Maybe$andThen = F2(
-	function (callback, maybeValue) {
-		if (maybeValue.$ === 'Just') {
-			var value = maybeValue.a;
-			return callback(value);
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
-	});
-var $elm$json$Json$Decode$decodeValue = _Json_run;
-var $elm$json$Json$Decode$value = _Json_decodeValue;
-var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
-	function (fieldName, decoder) {
-		var finishDecoding = function (json) {
-			var _v0 = A2(
-				$elm$json$Json$Decode$decodeValue,
-				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
-				json);
-			if (_v0.$ === 'Ok') {
-				var val = _v0.a;
-				return A2(
-					$elm$json$Json$Decode$map,
-					$elm$core$Maybe$Just,
-					A2($elm$json$Json$Decode$field, fieldName, decoder));
-			} else {
-				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
-			}
-		};
-		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
-	});
-var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
-	function (fieldName, decoder) {
-		return A2(
-			$elm$json$Json$Decode$map,
-			$elm$core$Maybe$andThen($elm$core$Basics$identity),
-			A2(
-				$elm_community$json_extra$Json$Decode$Extra$optionalField,
-				fieldName,
-				$elm$json$Json$Decode$nullable(decoder)));
-	});
 var $author$project$Main$decodeFormField = A2(
 	$elm_community$json_extra$Json$Decode$Extra$andMap,
 	A2($elm$json$Json$Decode$field, 'type', $author$project$Main$decodeInputField),
 	A2(
 		$elm_community$json_extra$Json$Decode$Extra$andMap,
-		A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
+		$author$project$Main$decodeFormFieldDescription,
 		A2(
 			$elm_community$json_extra$Json$Decode$Extra$andMap,
 			A2($elm$json$Json$Decode$field, 'presence', $author$project$Main$decodePresence),
 			A2(
 				$elm_community$json_extra$Json$Decode$Extra$andMap,
-				A2($elm_community$json_extra$Json$Decode$Extra$optionalNullableField, 'name', $elm$json$Json$Decode$string),
+				$author$project$Main$decodeFormFieldMaybeName,
 				A2(
 					$elm_community$json_extra$Json$Decode$Extra$andMap,
 					A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
@@ -5654,6 +5646,46 @@ var $author$project$Main$decodeViewMode = A2(
 	$elm_community$json_extra$Json$Decode$Extra$fromMaybe('Invalid viewMode: Editor | Preview | CollectData'),
 	A2($elm$json$Json$Decode$map, $author$project$Main$viewModeFromString, $elm$json$Json$Decode$string));
 var $elm$json$Json$Encode$null = _Json_encodeNull;
+var $elm$core$Maybe$andThen = F2(
+	function (callback, maybeValue) {
+		if (maybeValue.$ === 'Just') {
+			var value = maybeValue.a;
+			return callback(value);
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $elm$json$Json$Decode$decodeValue = _Json_run;
+var $elm$json$Json$Decode$value = _Json_decodeValue;
+var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
+	function (fieldName, decoder) {
+		var finishDecoding = function (json) {
+			var _v0 = A2(
+				$elm$json$Json$Decode$decodeValue,
+				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
+				json);
+			if (_v0.$ === 'Ok') {
+				var val = _v0.a;
+				return A2(
+					$elm$json$Json$Decode$map,
+					$elm$core$Maybe$Just,
+					A2($elm$json$Json$Decode$field, fieldName, decoder));
+			} else {
+				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
+			}
+		};
+		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
+	});
+var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
+	function (fieldName, decoder) {
+		return A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$andThen($elm$core$Basics$identity),
+			A2(
+				$elm_community$json_extra$Json$Decode$Extra$optionalField,
+				fieldName,
+				$elm$json$Json$Decode$nullable(decoder)));
+	});
 var $elm$core$Maybe$withDefault = F2(
 	function (_default, maybe) {
 		if (maybe.$ === 'Just') {
@@ -6964,10 +6996,6 @@ var $elm$html$Html$Events$on = F2(
 			$elm$virtual_dom$VirtualDom$on,
 			event,
 			$elm$virtual_dom$VirtualDom$Normal(decoder));
-	});
-var $elm$json$Json$Decode$at = F2(
-	function (fields, decoder) {
-		return A3($elm$core$List$foldr, $elm$json$Json$Decode$field, decoder, fields);
 	});
 var $elm$json$Json$Decode$bool = _Json_decodeBool;
 var $elm$html$Html$Events$targetChecked = A2(

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -5221,9 +5221,9 @@ var $author$project$Main$Config = F4(
 		return {formFields: formFields, formValues: formValues, shortTextTypeList: shortTextTypeList, viewMode: viewMode};
 	});
 var $elm_community$json_extra$Json$Decode$Extra$andMap = $elm$json$Json$Decode$map2($elm$core$Basics$apR);
-var $author$project$Main$FormField = F4(
-	function (label, presence, description, type_) {
-		return {description: description, label: label, presence: presence, type_: type_};
+var $author$project$Main$FormField = F5(
+	function (label, name, presence, description, type_) {
+		return {description: description, label: label, name: name, presence: presence, type_: type_};
 	});
 var $author$project$Main$ChooseMultiple = function (a) {
 	return {$: 'ChooseMultiple', a: a};
@@ -5336,13 +5336,8 @@ var $author$project$Main$decodeInputField = A2(
 		}
 	},
 	A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string));
-var $author$project$Main$SystemOptional = function (a) {
-	return {$: 'SystemOptional', a: a};
-};
-var $author$project$Main$SystemRequired = function (a) {
-	return {$: 'SystemRequired', a: a};
-};
 var $author$project$Main$Optional = {$: 'Optional'};
+var $author$project$Main$System = {$: 'System'};
 var $author$project$Main$Required = {$: 'Required'};
 var $author$project$Main$decodePresenceString = A2(
 	$elm$json$Json$Decode$andThen,
@@ -5352,6 +5347,8 @@ var $author$project$Main$decodePresenceString = A2(
 				return $elm$json$Json$Decode$succeed($author$project$Main$Required);
 			case 'Optional':
 				return $elm$json$Json$Decode$succeed($author$project$Main$Optional);
+			case 'System':
+				return $elm$json$Json$Decode$succeed($author$project$Main$System);
 			default:
 				return $elm$json$Json$Decode$fail('Unknown presence: ' + str);
 		}
@@ -5365,38 +5362,58 @@ var $author$project$Main$decodePresence = $elm$json$Json$Decode$oneOf(
 			$elm$json$Json$Decode$andThen,
 			function (type_) {
 				switch (type_) {
+					case 'System':
+						return $elm$json$Json$Decode$succeed($author$project$Main$System);
 					case 'SystemRequired':
-						return A2(
-							$elm_community$json_extra$Json$Decode$Extra$andMap,
-							A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
-							A2(
-								$elm_community$json_extra$Json$Decode$Extra$andMap,
-								A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string),
-								$elm$json$Json$Decode$succeed(
-									F2(
-										function (name, description) {
-											return $author$project$Main$SystemRequired(
-												{description: description, name: name});
-										}))));
+						return $elm$json$Json$Decode$succeed($author$project$Main$System);
 					case 'SystemOptional':
-						return A2(
-							$elm_community$json_extra$Json$Decode$Extra$andMap,
-							A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
-							A2(
-								$elm_community$json_extra$Json$Decode$Extra$andMap,
-								A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string),
-								$elm$json$Json$Decode$succeed(
-									F2(
-										function (name, description) {
-											return $author$project$Main$SystemOptional(
-												{description: description, name: name});
-										}))));
+						return $elm$json$Json$Decode$succeed($author$project$Main$Optional);
 					default:
 						return $elm$json$Json$Decode$fail('Unknown presence type: ' + type_);
 				}
 			},
 			A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string))
 		]));
+var $elm$core$Maybe$andThen = F2(
+	function (callback, maybeValue) {
+		if (maybeValue.$ === 'Just') {
+			var value = maybeValue.a;
+			return callback(value);
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $elm$json$Json$Decode$decodeValue = _Json_run;
+var $elm$json$Json$Decode$value = _Json_decodeValue;
+var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
+	function (fieldName, decoder) {
+		var finishDecoding = function (json) {
+			var _v0 = A2(
+				$elm$json$Json$Decode$decodeValue,
+				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
+				json);
+			if (_v0.$ === 'Ok') {
+				var val = _v0.a;
+				return A2(
+					$elm$json$Json$Decode$map,
+					$elm$core$Maybe$Just,
+					A2($elm$json$Json$Decode$field, fieldName, decoder));
+			} else {
+				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
+			}
+		};
+		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
+	});
+var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
+	function (fieldName, decoder) {
+		return A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$andThen($elm$core$Basics$identity),
+			A2(
+				$elm_community$json_extra$Json$Decode$Extra$optionalField,
+				fieldName,
+				$elm$json$Json$Decode$nullable(decoder)));
+	});
 var $author$project$Main$decodeFormField = A2(
 	$elm_community$json_extra$Json$Decode$Extra$andMap,
 	A2($elm$json$Json$Decode$field, 'type', $author$project$Main$decodeInputField),
@@ -5408,8 +5425,11 @@ var $author$project$Main$decodeFormField = A2(
 			A2($elm$json$Json$Decode$field, 'presence', $author$project$Main$decodePresence),
 			A2(
 				$elm_community$json_extra$Json$Decode$Extra$andMap,
-				A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
-				$elm$json$Json$Decode$succeed($author$project$Main$FormField)))));
+				A2($elm_community$json_extra$Json$Decode$Extra$optionalNullableField, 'name', $elm$json$Json$Decode$string),
+				A2(
+					$elm_community$json_extra$Json$Decode$Extra$andMap,
+					A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
+					$elm$json$Json$Decode$succeed($author$project$Main$FormField))))));
 var $elm$core$Array$fromListHelp = F3(
 	function (list, nodeList, nodeListSize) {
 		fromListHelp:
@@ -5634,46 +5654,6 @@ var $author$project$Main$decodeViewMode = A2(
 	$elm_community$json_extra$Json$Decode$Extra$fromMaybe('Invalid viewMode: Editor | Preview | CollectData'),
 	A2($elm$json$Json$Decode$map, $author$project$Main$viewModeFromString, $elm$json$Json$Decode$string));
 var $elm$json$Json$Encode$null = _Json_encodeNull;
-var $elm$core$Maybe$andThen = F2(
-	function (callback, maybeValue) {
-		if (maybeValue.$ === 'Just') {
-			var value = maybeValue.a;
-			return callback(value);
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
-	});
-var $elm$json$Json$Decode$decodeValue = _Json_run;
-var $elm$json$Json$Decode$value = _Json_decodeValue;
-var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
-	function (fieldName, decoder) {
-		var finishDecoding = function (json) {
-			var _v0 = A2(
-				$elm$json$Json$Decode$decodeValue,
-				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
-				json);
-			if (_v0.$ === 'Ok') {
-				var val = _v0.a;
-				return A2(
-					$elm$json$Json$Decode$map,
-					$elm$core$Maybe$Just,
-					A2($elm$json$Json$Decode$field, fieldName, decoder));
-			} else {
-				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
-			}
-		};
-		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
-	});
-var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
-	function (fieldName, decoder) {
-		return A2(
-			$elm$json$Json$Decode$map,
-			$elm$core$Maybe$andThen($elm$core$Basics$identity),
-			A2(
-				$elm_community$json_extra$Json$Decode$Extra$optionalField,
-				fieldName,
-				$elm$json$Json$Decode$nullable(decoder)));
-	});
 var $elm$core$Maybe$withDefault = F2(
 	function (_default, maybe) {
 		if (maybe.$ === 'Just') {
@@ -5883,36 +5863,8 @@ var $author$project$Main$encodePresence = function (presence) {
 			return $elm$json$Json$Encode$string('Required');
 		case 'Optional':
 			return $elm$json$Json$Encode$string('Optional');
-		case 'SystemRequired':
-			var sys = presence.a;
-			return $elm$json$Json$Encode$object(
-				_List_fromArray(
-					[
-						_Utils_Tuple2(
-						'type',
-						$elm$json$Json$Encode$string('SystemRequired')),
-						_Utils_Tuple2(
-						'name',
-						$elm$json$Json$Encode$string(sys.name)),
-						_Utils_Tuple2(
-						'description',
-						$elm$json$Json$Encode$string(sys.description))
-					]));
 		default:
-			var sys = presence.a;
-			return $elm$json$Json$Encode$object(
-				_List_fromArray(
-					[
-						_Utils_Tuple2(
-						'type',
-						$elm$json$Json$Encode$string('SystemOptional')),
-						_Utils_Tuple2(
-						'name',
-						$elm$json$Json$Encode$string(sys.name)),
-						_Utils_Tuple2(
-						'description',
-						$elm$json$Json$Encode$string(sys.description))
-					]));
+			return $elm$json$Json$Encode$string('System');
 	}
 };
 var $author$project$Main$encodeFormFields = function (formFields) {
@@ -5925,8 +5877,8 @@ var $author$project$Main$encodeFormFields = function (formFields) {
 				return $elm$json$Json$Encode$object(
 					A2(
 						$elm$core$List$filter,
-						function (_v0) {
-							var v = _v0.b;
+						function (_v1) {
+							var v = _v1.b;
 							return !_Utils_eq(v, $elm$json$Json$Encode$null);
 						},
 						_List_fromArray(
@@ -5934,6 +5886,17 @@ var $author$project$Main$encodeFormFields = function (formFields) {
 								_Utils_Tuple2(
 								'label',
 								$elm$json$Json$Encode$string(formField.label)),
+								_Utils_Tuple2(
+								'name',
+								function () {
+									var _v0 = formField.name;
+									if (_v0.$ === 'Just') {
+										var name = _v0.a;
+										return $elm$json$Json$Encode$string(name);
+									} else {
+										return $elm$json$Json$Encode$null;
+									}
+								}()),
 								_Utils_Tuple2(
 								'presence',
 								$author$project$Main$encodePresence(formField.presence)),
@@ -6560,6 +6523,7 @@ var $author$project$Main$update = F2(
 				var newFormField = {
 					description: '',
 					label: 'Question ' + $elm$core$String$fromInt(currLength + 1),
+					name: $elm$core$Maybe$Nothing,
 					presence: A2(
 						$author$project$Main$when,
 						$author$project$Main$mustBeOptional(fieldType),
@@ -7048,10 +7012,8 @@ var $author$project$Main$requiredData = function (presence) {
 			return true;
 		case 'Optional':
 			return false;
-		case 'SystemRequired':
-			return true;
 		default:
-			return false;
+			return true;
 	}
 };
 var $elm$html$Html$Attributes$tabindex = function (n) {
@@ -7147,8 +7109,6 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 											return false;
 										case 'Optional':
 											return false;
-										case 'SystemRequired':
-											return true;
 										default:
 											return true;
 									}
@@ -7429,20 +7389,7 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 											return configureRequiredCheckbox;
 										case 'Optional':
 											return configureRequiredCheckbox;
-										case 'SystemRequired':
-											var sys = _v0.a;
-											return A2(
-												$elm$html$Html$div,
-												_List_fromArray(
-													[
-														$elm$html$Html$Attributes$class('tff-field-description')
-													]),
-												_List_fromArray(
-													[
-														$elm$html$Html$text(sys.description)
-													]));
 										default:
-											var sys = _v0.a;
 											return A2(
 												$elm$html$Html$div,
 												_List_fromArray(
@@ -7451,7 +7398,7 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 													]),
 												_List_fromArray(
 													[
-														$elm$html$Html$text(sys.description)
+														$elm$html$Html$text(formField.description)
 													]));
 									}
 								}
@@ -7545,8 +7492,6 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 											return deleteFieldButton;
 										case 'Optional':
 											return deleteFieldButton;
-										case 'SystemRequired':
-											return $elm$html$Html$text('');
 										default:
 											return $elm$html$Html$text('');
 									}
@@ -7638,19 +7583,7 @@ var $author$project$Main$maybeMaxLengthOf = function (formField) {
 	}
 };
 var $author$project$Main$fieldNameOf = function (formField) {
-	var _v0 = formField.presence;
-	switch (_v0.$) {
-		case 'Required':
-			return formField.label;
-		case 'Optional':
-			return formField.label;
-		case 'SystemRequired':
-			var name = _v0.a.name;
-			return name;
-		default:
-			var name = _v0.a.name;
-			return name;
-	}
+	return A2($elm$core$Maybe$withDefault, formField.label, formField.name);
 };
 var $elm$core$List$maybeCons = F3(
 	function (f, mx, xs) {
@@ -7731,26 +7664,15 @@ var $author$project$Main$viewFormFieldOptionsPreview = F2(
 		var shortTextTypeDict = _v0.shortTextTypeDict;
 		var fieldName = $author$project$Main$fieldNameOf(formField);
 		var chosenForYou = function (choices) {
-			var _v3 = _Utils_Tuple2(formField.presence, choices);
-			_v3$2:
-			while (true) {
-				if (_v3.b.b && (!_v3.b.b.b)) {
-					switch (_v3.a.$) {
-						case 'SystemRequired':
-							var _v4 = _v3.b;
-							return true;
-						case 'Required':
-							var _v5 = _v3.a;
-							var _v6 = _v3.b;
-							return true;
-						default:
-							break _v3$2;
-					}
-				} else {
-					break _v3$2;
-				}
+			var _v3 = formField.presence;
+			switch (_v3.$) {
+				case 'Optional':
+					return false;
+				case 'Required':
+					return $elm$core$List$length(choices) === 1;
+				default:
+					return $elm$core$List$length(choices) === 1;
 			}
-			return false;
 		};
 		var _v1 = formField.type_;
 		switch (_v1.$) {
@@ -8070,10 +7992,8 @@ var $author$project$Main$viewFormFieldPreview = F2(
 											return $elm$html$Html$text('');
 										case 'Optional':
 											return $elm$html$Html$text(' (optional)');
-										case 'SystemRequired':
-											return $elm$html$Html$text('');
 										default:
-											return $elm$html$Html$text(' (optional)');
+											return $elm$html$Html$text('');
 									}
 								}()
 								])),

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -5213,9 +5213,9 @@ var $author$project$Main$Config = F4(
 		return {formFields: formFields, formValues: formValues, shortTextTypeList: shortTextTypeList, viewMode: viewMode};
 	});
 var $elm_community$json_extra$Json$Decode$Extra$andMap = $elm$json$Json$Decode$map2($elm$core$Basics$apR);
-var $author$project$Main$FormField = F4(
-	function (label, presence, description, type_) {
-		return {description: description, label: label, presence: presence, type_: type_};
+var $author$project$Main$FormField = F5(
+	function (label, name, presence, description, type_) {
+		return {description: description, label: label, name: name, presence: presence, type_: type_};
 	});
 var $author$project$Main$ChooseMultiple = function (a) {
 	return {$: 'ChooseMultiple', a: a};
@@ -5328,13 +5328,8 @@ var $author$project$Main$decodeInputField = A2(
 		}
 	},
 	A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string));
-var $author$project$Main$SystemOptional = function (a) {
-	return {$: 'SystemOptional', a: a};
-};
-var $author$project$Main$SystemRequired = function (a) {
-	return {$: 'SystemRequired', a: a};
-};
 var $author$project$Main$Optional = {$: 'Optional'};
+var $author$project$Main$System = {$: 'System'};
 var $author$project$Main$Required = {$: 'Required'};
 var $author$project$Main$decodePresenceString = A2(
 	$elm$json$Json$Decode$andThen,
@@ -5344,6 +5339,8 @@ var $author$project$Main$decodePresenceString = A2(
 				return $elm$json$Json$Decode$succeed($author$project$Main$Required);
 			case 'Optional':
 				return $elm$json$Json$Decode$succeed($author$project$Main$Optional);
+			case 'System':
+				return $elm$json$Json$Decode$succeed($author$project$Main$System);
 			default:
 				return $elm$json$Json$Decode$fail('Unknown presence: ' + str);
 		}
@@ -5357,38 +5354,58 @@ var $author$project$Main$decodePresence = $elm$json$Json$Decode$oneOf(
 			$elm$json$Json$Decode$andThen,
 			function (type_) {
 				switch (type_) {
+					case 'System':
+						return $elm$json$Json$Decode$succeed($author$project$Main$System);
 					case 'SystemRequired':
-						return A2(
-							$elm_community$json_extra$Json$Decode$Extra$andMap,
-							A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
-							A2(
-								$elm_community$json_extra$Json$Decode$Extra$andMap,
-								A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string),
-								$elm$json$Json$Decode$succeed(
-									F2(
-										function (name, description) {
-											return $author$project$Main$SystemRequired(
-												{description: description, name: name});
-										}))));
+						return $elm$json$Json$Decode$succeed($author$project$Main$System);
 					case 'SystemOptional':
-						return A2(
-							$elm_community$json_extra$Json$Decode$Extra$andMap,
-							A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
-							A2(
-								$elm_community$json_extra$Json$Decode$Extra$andMap,
-								A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string),
-								$elm$json$Json$Decode$succeed(
-									F2(
-										function (name, description) {
-											return $author$project$Main$SystemOptional(
-												{description: description, name: name});
-										}))));
+						return $elm$json$Json$Decode$succeed($author$project$Main$Optional);
 					default:
 						return $elm$json$Json$Decode$fail('Unknown presence type: ' + type_);
 				}
 			},
 			A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string))
 		]));
+var $elm$core$Maybe$andThen = F2(
+	function (callback, maybeValue) {
+		if (maybeValue.$ === 'Just') {
+			var value = maybeValue.a;
+			return callback(value);
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $elm$json$Json$Decode$decodeValue = _Json_run;
+var $elm$json$Json$Decode$value = _Json_decodeValue;
+var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
+	function (fieldName, decoder) {
+		var finishDecoding = function (json) {
+			var _v0 = A2(
+				$elm$json$Json$Decode$decodeValue,
+				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
+				json);
+			if (_v0.$ === 'Ok') {
+				var val = _v0.a;
+				return A2(
+					$elm$json$Json$Decode$map,
+					$elm$core$Maybe$Just,
+					A2($elm$json$Json$Decode$field, fieldName, decoder));
+			} else {
+				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
+			}
+		};
+		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
+	});
+var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
+	function (fieldName, decoder) {
+		return A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$andThen($elm$core$Basics$identity),
+			A2(
+				$elm_community$json_extra$Json$Decode$Extra$optionalField,
+				fieldName,
+				$elm$json$Json$Decode$nullable(decoder)));
+	});
 var $author$project$Main$decodeFormField = A2(
 	$elm_community$json_extra$Json$Decode$Extra$andMap,
 	A2($elm$json$Json$Decode$field, 'type', $author$project$Main$decodeInputField),
@@ -5400,8 +5417,11 @@ var $author$project$Main$decodeFormField = A2(
 			A2($elm$json$Json$Decode$field, 'presence', $author$project$Main$decodePresence),
 			A2(
 				$elm_community$json_extra$Json$Decode$Extra$andMap,
-				A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
-				$elm$json$Json$Decode$succeed($author$project$Main$FormField)))));
+				A2($elm_community$json_extra$Json$Decode$Extra$optionalNullableField, 'name', $elm$json$Json$Decode$string),
+				A2(
+					$elm_community$json_extra$Json$Decode$Extra$andMap,
+					A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
+					$elm$json$Json$Decode$succeed($author$project$Main$FormField))))));
 var $elm$core$Array$fromListHelp = F3(
 	function (list, nodeList, nodeListSize) {
 		fromListHelp:
@@ -5626,46 +5646,6 @@ var $author$project$Main$decodeViewMode = A2(
 	$elm_community$json_extra$Json$Decode$Extra$fromMaybe('Invalid viewMode: Editor | Preview | CollectData'),
 	A2($elm$json$Json$Decode$map, $author$project$Main$viewModeFromString, $elm$json$Json$Decode$string));
 var $elm$json$Json$Encode$null = _Json_encodeNull;
-var $elm$core$Maybe$andThen = F2(
-	function (callback, maybeValue) {
-		if (maybeValue.$ === 'Just') {
-			var value = maybeValue.a;
-			return callback(value);
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
-	});
-var $elm$json$Json$Decode$decodeValue = _Json_run;
-var $elm$json$Json$Decode$value = _Json_decodeValue;
-var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
-	function (fieldName, decoder) {
-		var finishDecoding = function (json) {
-			var _v0 = A2(
-				$elm$json$Json$Decode$decodeValue,
-				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
-				json);
-			if (_v0.$ === 'Ok') {
-				var val = _v0.a;
-				return A2(
-					$elm$json$Json$Decode$map,
-					$elm$core$Maybe$Just,
-					A2($elm$json$Json$Decode$field, fieldName, decoder));
-			} else {
-				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
-			}
-		};
-		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
-	});
-var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
-	function (fieldName, decoder) {
-		return A2(
-			$elm$json$Json$Decode$map,
-			$elm$core$Maybe$andThen($elm$core$Basics$identity),
-			A2(
-				$elm_community$json_extra$Json$Decode$Extra$optionalField,
-				fieldName,
-				$elm$json$Json$Decode$nullable(decoder)));
-	});
 var $elm$core$Maybe$withDefault = F2(
 	function (_default, maybe) {
 		if (maybe.$ === 'Just') {
@@ -5875,36 +5855,8 @@ var $author$project$Main$encodePresence = function (presence) {
 			return $elm$json$Json$Encode$string('Required');
 		case 'Optional':
 			return $elm$json$Json$Encode$string('Optional');
-		case 'SystemRequired':
-			var sys = presence.a;
-			return $elm$json$Json$Encode$object(
-				_List_fromArray(
-					[
-						_Utils_Tuple2(
-						'type',
-						$elm$json$Json$Encode$string('SystemRequired')),
-						_Utils_Tuple2(
-						'name',
-						$elm$json$Json$Encode$string(sys.name)),
-						_Utils_Tuple2(
-						'description',
-						$elm$json$Json$Encode$string(sys.description))
-					]));
 		default:
-			var sys = presence.a;
-			return $elm$json$Json$Encode$object(
-				_List_fromArray(
-					[
-						_Utils_Tuple2(
-						'type',
-						$elm$json$Json$Encode$string('SystemOptional')),
-						_Utils_Tuple2(
-						'name',
-						$elm$json$Json$Encode$string(sys.name)),
-						_Utils_Tuple2(
-						'description',
-						$elm$json$Json$Encode$string(sys.description))
-					]));
+			return $elm$json$Json$Encode$string('System');
 	}
 };
 var $author$project$Main$encodeFormFields = function (formFields) {
@@ -5917,8 +5869,8 @@ var $author$project$Main$encodeFormFields = function (formFields) {
 				return $elm$json$Json$Encode$object(
 					A2(
 						$elm$core$List$filter,
-						function (_v0) {
-							var v = _v0.b;
+						function (_v1) {
+							var v = _v1.b;
 							return !_Utils_eq(v, $elm$json$Json$Encode$null);
 						},
 						_List_fromArray(
@@ -5926,6 +5878,17 @@ var $author$project$Main$encodeFormFields = function (formFields) {
 								_Utils_Tuple2(
 								'label',
 								$elm$json$Json$Encode$string(formField.label)),
+								_Utils_Tuple2(
+								'name',
+								function () {
+									var _v0 = formField.name;
+									if (_v0.$ === 'Just') {
+										var name = _v0.a;
+										return $elm$json$Json$Encode$string(name);
+									} else {
+										return $elm$json$Json$Encode$null;
+									}
+								}()),
 								_Utils_Tuple2(
 								'presence',
 								$author$project$Main$encodePresence(formField.presence)),
@@ -6552,6 +6515,7 @@ var $author$project$Main$update = F2(
 				var newFormField = {
 					description: '',
 					label: 'Question ' + $elm$core$String$fromInt(currLength + 1),
+					name: $elm$core$Maybe$Nothing,
 					presence: A2(
 						$author$project$Main$when,
 						$author$project$Main$mustBeOptional(fieldType),
@@ -7040,10 +7004,8 @@ var $author$project$Main$requiredData = function (presence) {
 			return true;
 		case 'Optional':
 			return false;
-		case 'SystemRequired':
-			return true;
 		default:
-			return false;
+			return true;
 	}
 };
 var $elm$html$Html$Attributes$tabindex = function (n) {
@@ -7139,8 +7101,6 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 											return false;
 										case 'Optional':
 											return false;
-										case 'SystemRequired':
-											return true;
 										default:
 											return true;
 									}
@@ -7421,20 +7381,7 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 											return configureRequiredCheckbox;
 										case 'Optional':
 											return configureRequiredCheckbox;
-										case 'SystemRequired':
-											var sys = _v0.a;
-											return A2(
-												$elm$html$Html$div,
-												_List_fromArray(
-													[
-														$elm$html$Html$Attributes$class('tff-field-description')
-													]),
-												_List_fromArray(
-													[
-														$elm$html$Html$text(sys.description)
-													]));
 										default:
-											var sys = _v0.a;
 											return A2(
 												$elm$html$Html$div,
 												_List_fromArray(
@@ -7443,7 +7390,7 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 													]),
 												_List_fromArray(
 													[
-														$elm$html$Html$text(sys.description)
+														$elm$html$Html$text(formField.description)
 													]));
 									}
 								}
@@ -7537,8 +7484,6 @@ var $author$project$Main$viewFormFieldBuilder = F5(
 											return deleteFieldButton;
 										case 'Optional':
 											return deleteFieldButton;
-										case 'SystemRequired':
-											return $elm$html$Html$text('');
 										default:
 											return $elm$html$Html$text('');
 									}
@@ -7630,19 +7575,7 @@ var $author$project$Main$maybeMaxLengthOf = function (formField) {
 	}
 };
 var $author$project$Main$fieldNameOf = function (formField) {
-	var _v0 = formField.presence;
-	switch (_v0.$) {
-		case 'Required':
-			return formField.label;
-		case 'Optional':
-			return formField.label;
-		case 'SystemRequired':
-			var name = _v0.a.name;
-			return name;
-		default:
-			var name = _v0.a.name;
-			return name;
-	}
+	return A2($elm$core$Maybe$withDefault, formField.label, formField.name);
 };
 var $elm$core$List$maybeCons = F3(
 	function (f, mx, xs) {
@@ -7723,26 +7656,15 @@ var $author$project$Main$viewFormFieldOptionsPreview = F2(
 		var shortTextTypeDict = _v0.shortTextTypeDict;
 		var fieldName = $author$project$Main$fieldNameOf(formField);
 		var chosenForYou = function (choices) {
-			var _v3 = _Utils_Tuple2(formField.presence, choices);
-			_v3$2:
-			while (true) {
-				if (_v3.b.b && (!_v3.b.b.b)) {
-					switch (_v3.a.$) {
-						case 'SystemRequired':
-							var _v4 = _v3.b;
-							return true;
-						case 'Required':
-							var _v5 = _v3.a;
-							var _v6 = _v3.b;
-							return true;
-						default:
-							break _v3$2;
-					}
-				} else {
-					break _v3$2;
-				}
+			var _v3 = formField.presence;
+			switch (_v3.$) {
+				case 'Optional':
+					return false;
+				case 'Required':
+					return $elm$core$List$length(choices) === 1;
+				default:
+					return $elm$core$List$length(choices) === 1;
 			}
-			return false;
 		};
 		var _v1 = formField.type_;
 		switch (_v1.$) {
@@ -8062,10 +7984,8 @@ var $author$project$Main$viewFormFieldPreview = F2(
 											return $elm$html$Html$text('');
 										case 'Optional':
 											return $elm$html$Html$text(' (optional)');
-										case 'SystemRequired':
-											return $elm$html$Html$text('');
 										default:
-											return $elm$html$Html$text(' (optional)');
+											return $elm$html$Html$text('');
 									}
 								}()
 								])),

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -5217,6 +5217,41 @@ var $author$project$Main$FormField = F5(
 	function (label, name, presence, description, type_) {
 		return {description: description, label: label, name: name, presence: presence, type_: type_};
 	});
+var $elm$json$Json$Decode$field = _Json_decodeField;
+var $elm$json$Json$Decode$at = F2(
+	function (fields, decoder) {
+		return A3($elm$core$List$foldr, $elm$json$Json$Decode$field, decoder, fields);
+	});
+var $elm$json$Json$Decode$oneOf = _Json_oneOf;
+var $elm$json$Json$Decode$string = _Json_decodeString;
+var $author$project$Main$decodeFormFieldDescription = $elm$json$Json$Decode$oneOf(
+	_List_fromArray(
+		[
+			A2(
+			$elm$json$Json$Decode$at,
+			_List_fromArray(
+				['presence', 'description']),
+			$elm$json$Json$Decode$string),
+			A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
+			$elm$json$Json$Decode$succeed('')
+		]));
+var $author$project$Main$decodeFormFieldMaybeName = $elm$json$Json$Decode$oneOf(
+	_List_fromArray(
+		[
+			A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$Just,
+			A2(
+				$elm$json$Json$Decode$at,
+				_List_fromArray(
+					['presence', 'name']),
+				$elm$json$Json$Decode$string)),
+			A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$Just,
+			A2($elm$json$Json$Decode$field, 'name', $elm$json$Json$Decode$string)),
+			$elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing)
+		]));
 var $author$project$Main$ChooseMultiple = function (a) {
 	return {$: 'ChooseMultiple', a: a};
 };
@@ -5260,14 +5295,11 @@ var $author$project$Main$choiceFromString = function (s) {
 		return {label: s, value: s};
 	}
 };
-var $elm$json$Json$Decode$string = _Json_decodeString;
 var $author$project$Main$decodeChoice = A2($elm$json$Json$Decode$map, $author$project$Main$choiceFromString, $elm$json$Json$Decode$string);
 var $elm$json$Json$Decode$fail = _Json_fail;
-var $elm$json$Json$Decode$field = _Json_decodeField;
 var $elm$json$Json$Decode$int = _Json_decodeInt;
 var $elm$json$Json$Decode$list = _Json_decodeList;
 var $elm$json$Json$Decode$null = _Json_decodeNull;
-var $elm$json$Json$Decode$oneOf = _Json_oneOf;
 var $elm$json$Json$Decode$nullable = function (decoder) {
 	return $elm$json$Json$Decode$oneOf(
 		_List_fromArray(
@@ -5366,58 +5398,18 @@ var $author$project$Main$decodePresence = $elm$json$Json$Decode$oneOf(
 			},
 			A2($elm$json$Json$Decode$field, 'type', $elm$json$Json$Decode$string))
 		]));
-var $elm$core$Maybe$andThen = F2(
-	function (callback, maybeValue) {
-		if (maybeValue.$ === 'Just') {
-			var value = maybeValue.a;
-			return callback(value);
-		} else {
-			return $elm$core$Maybe$Nothing;
-		}
-	});
-var $elm$json$Json$Decode$decodeValue = _Json_run;
-var $elm$json$Json$Decode$value = _Json_decodeValue;
-var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
-	function (fieldName, decoder) {
-		var finishDecoding = function (json) {
-			var _v0 = A2(
-				$elm$json$Json$Decode$decodeValue,
-				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
-				json);
-			if (_v0.$ === 'Ok') {
-				var val = _v0.a;
-				return A2(
-					$elm$json$Json$Decode$map,
-					$elm$core$Maybe$Just,
-					A2($elm$json$Json$Decode$field, fieldName, decoder));
-			} else {
-				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
-			}
-		};
-		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
-	});
-var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
-	function (fieldName, decoder) {
-		return A2(
-			$elm$json$Json$Decode$map,
-			$elm$core$Maybe$andThen($elm$core$Basics$identity),
-			A2(
-				$elm_community$json_extra$Json$Decode$Extra$optionalField,
-				fieldName,
-				$elm$json$Json$Decode$nullable(decoder)));
-	});
 var $author$project$Main$decodeFormField = A2(
 	$elm_community$json_extra$Json$Decode$Extra$andMap,
 	A2($elm$json$Json$Decode$field, 'type', $author$project$Main$decodeInputField),
 	A2(
 		$elm_community$json_extra$Json$Decode$Extra$andMap,
-		A2($elm$json$Json$Decode$field, 'description', $elm$json$Json$Decode$string),
+		$author$project$Main$decodeFormFieldDescription,
 		A2(
 			$elm_community$json_extra$Json$Decode$Extra$andMap,
 			A2($elm$json$Json$Decode$field, 'presence', $author$project$Main$decodePresence),
 			A2(
 				$elm_community$json_extra$Json$Decode$Extra$andMap,
-				A2($elm_community$json_extra$Json$Decode$Extra$optionalNullableField, 'name', $elm$json$Json$Decode$string),
+				$author$project$Main$decodeFormFieldMaybeName,
 				A2(
 					$elm_community$json_extra$Json$Decode$Extra$andMap,
 					A2($elm$json$Json$Decode$field, 'label', $elm$json$Json$Decode$string),
@@ -5646,6 +5638,46 @@ var $author$project$Main$decodeViewMode = A2(
 	$elm_community$json_extra$Json$Decode$Extra$fromMaybe('Invalid viewMode: Editor | Preview | CollectData'),
 	A2($elm$json$Json$Decode$map, $author$project$Main$viewModeFromString, $elm$json$Json$Decode$string));
 var $elm$json$Json$Encode$null = _Json_encodeNull;
+var $elm$core$Maybe$andThen = F2(
+	function (callback, maybeValue) {
+		if (maybeValue.$ === 'Just') {
+			var value = maybeValue.a;
+			return callback(value);
+		} else {
+			return $elm$core$Maybe$Nothing;
+		}
+	});
+var $elm$json$Json$Decode$decodeValue = _Json_run;
+var $elm$json$Json$Decode$value = _Json_decodeValue;
+var $elm_community$json_extra$Json$Decode$Extra$optionalField = F2(
+	function (fieldName, decoder) {
+		var finishDecoding = function (json) {
+			var _v0 = A2(
+				$elm$json$Json$Decode$decodeValue,
+				A2($elm$json$Json$Decode$field, fieldName, $elm$json$Json$Decode$value),
+				json);
+			if (_v0.$ === 'Ok') {
+				var val = _v0.a;
+				return A2(
+					$elm$json$Json$Decode$map,
+					$elm$core$Maybe$Just,
+					A2($elm$json$Json$Decode$field, fieldName, decoder));
+			} else {
+				return $elm$json$Json$Decode$succeed($elm$core$Maybe$Nothing);
+			}
+		};
+		return A2($elm$json$Json$Decode$andThen, finishDecoding, $elm$json$Json$Decode$value);
+	});
+var $elm_community$json_extra$Json$Decode$Extra$optionalNullableField = F2(
+	function (fieldName, decoder) {
+		return A2(
+			$elm$json$Json$Decode$map,
+			$elm$core$Maybe$andThen($elm$core$Basics$identity),
+			A2(
+				$elm_community$json_extra$Json$Decode$Extra$optionalField,
+				fieldName,
+				$elm$json$Json$Decode$nullable(decoder)));
+	});
 var $elm$core$Maybe$withDefault = F2(
 	function (_default, maybe) {
 		if (maybe.$ === 'Just') {
@@ -6956,10 +6988,6 @@ var $elm$html$Html$Events$on = F2(
 			$elm$virtual_dom$VirtualDom$on,
 			event,
 			$elm$virtual_dom$VirtualDom$Normal(decoder));
-	});
-var $elm$json$Json$Decode$at = F2(
-	function (fields, decoder) {
-		return A3($elm$core$List$foldr, $elm$json$Json$Decode$field, decoder, fields);
 	});
 var $elm$json$Json$Decode$bool = _Json_decodeBool;
 var $elm$html$Html$Events$targetChecked = A2(

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -112,15 +112,10 @@ stringFromViewMode viewMode =
             "CollectData"
 
 
-type alias System =
-    { name : String, description : String }
-
-
 type Presence
     = Required
     | Optional
-    | SystemRequired System
-    | SystemOptional System
+    | System
 
 
 requiredData : Presence -> Bool
@@ -132,15 +127,13 @@ requiredData presence =
         Optional ->
             False
 
-        SystemRequired _ ->
+        System ->
             True
-
-        SystemOptional _ ->
-            False
 
 
 type alias FormField =
     { label : String
+    , name : Maybe String
     , presence : Presence
     , description : String
     , type_ : InputField
@@ -327,6 +320,7 @@ update msg model =
                 newFormField : FormField
                 newFormField =
                     { label = "Question " ++ String.fromInt (currLength + 1)
+                    , name = Nothing
                     , presence = when (mustBeOptional fieldType) { true = Optional, false = Required }
                     , description = ""
                     , type_ = fieldType
@@ -638,11 +632,8 @@ viewFormFieldPreview config formField =
                     Optional ->
                         text " (optional)"
 
-                    SystemRequired _ ->
+                    System ->
                         text ""
-
-                    SystemOptional _ ->
-                        text " (optional)"
                 ]
             , viewFormFieldOptionsPreview config formField
             , div [ class "tff-field-description" ]
@@ -673,18 +664,7 @@ maybeMaxLengthOf formField =
 
 fieldNameOf : FormField -> String
 fieldNameOf formField =
-    case formField.presence of
-        Required ->
-            formField.label
-
-        Optional ->
-            formField.label
-
-        SystemRequired { name } ->
-            name
-
-        SystemOptional { name } ->
-            name
+    Maybe.withDefault formField.label formField.name
 
 
 viewFormFieldOptionsPreview : { formValues : Json.Encode.Value, customAttrs : List (Html.Attribute Msg), shortTextTypeDict : Dict String (Dict String String) } -> FormField -> Html Msg
@@ -694,15 +674,15 @@ viewFormFieldOptionsPreview { formValues, customAttrs, shortTextTypeDict } formF
             fieldNameOf formField
 
         chosenForYou choices =
-            case ( formField.presence, choices ) of
-                ( SystemRequired _, [ _ ] ) ->
-                    True
-
-                ( Required, [ _ ] ) ->
-                    True
-
-                _ ->
+            case formField.presence of
+                Optional ->
                     False
+
+                Required ->
+                    List.length choices == 1
+
+                System ->
+                    List.length choices == 1
     in
     case formField.type_ of
         ShortText inputType maybeMaxLength ->
@@ -1052,13 +1032,9 @@ viewFormFieldBuilder maybeAnimate shortTextTypeList totalLength index formField 
                     Optional ->
                         configureRequiredCheckbox
 
-                    SystemRequired sys ->
+                    System ->
                         div [ class "tff-field-description" ]
-                            [ text sys.description ]
-
-                    SystemOptional sys ->
-                        div [ class "tff-field-description" ]
-                            [ text sys.description ]
+                            [ text formField.description ]
             ]
          , div [ class "tff-field-group" ]
             [ label [ class "tff-field-label", for ("description-" ++ idSuffix) ] [ text "Description (optional)" ]
@@ -1104,10 +1080,7 @@ viewFormFieldBuilder maybeAnimate shortTextTypeList totalLength index formField 
                         Optional ->
                             deleteFieldButton
 
-                        SystemRequired _ ->
-                            text ""
-
-                        SystemOptional _ ->
+                        System ->
                             text ""
                     ]
                ]
@@ -1135,10 +1108,7 @@ viewFormFieldOptionsBuilder shortTextTypeList index formField =
                             Optional ->
                                 False
 
-                            SystemRequired _ ->
-                                True
-
-                            SystemOptional _ ->
+                            System ->
                                 True
                         )
                     , onInput (OnFormField OnChoicesInput index)
@@ -1361,19 +1331,8 @@ encodePresence presence =
         Optional ->
             Json.Encode.string "Optional"
 
-        SystemRequired sys ->
-            Json.Encode.object
-                [ ( "type", Json.Encode.string "SystemRequired" )
-                , ( "name", Json.Encode.string sys.name )
-                , ( "description", Json.Encode.string sys.description )
-                ]
-
-        SystemOptional sys ->
-            Json.Encode.object
-                [ ( "type", Json.Encode.string "SystemOptional" )
-                , ( "name", Json.Encode.string sys.name )
-                , ( "description", Json.Encode.string sys.description )
-                ]
+        System ->
+            Json.Encode.string "System"
 
 
 decodePresenceString : Json.Decode.Decoder Presence
@@ -1388,6 +1347,9 @@ decodePresenceString =
                     "Optional" ->
                         Json.Decode.succeed Optional
 
+                    "System" ->
+                        Json.Decode.succeed System
+
                     _ ->
                         Json.Decode.fail ("Unknown presence: " ++ str)
             )
@@ -1397,25 +1359,22 @@ decodePresence : Json.Decode.Decoder Presence
 decodePresence =
     Json.Decode.oneOf
         [ decodePresenceString
+
+        -- for backwards compatibility
         , Json.Decode.field "type" Json.Decode.string
             |> Json.Decode.andThen
                 (\type_ ->
                     case type_ of
                         "System" ->
-                            -- for backwards compatibility of change from System -> SystemRequired
-                            Json.Decode.succeed (\name description -> SystemRequired { name = name, description = description })
-                                |> andMap (Json.Decode.field "name" Json.Decode.string)
-                                |> andMap (Json.Decode.field "description" Json.Decode.string)
+                            Json.Decode.succeed System
 
                         "SystemRequired" ->
-                            Json.Decode.succeed (\name description -> SystemRequired { name = name, description = description })
-                                |> andMap (Json.Decode.field "name" Json.Decode.string)
-                                |> andMap (Json.Decode.field "description" Json.Decode.string)
+                            Json.Decode.succeed System
 
                         "SystemOptional" ->
-                            Json.Decode.succeed (\name description -> SystemOptional { name = name, description = description })
-                                |> andMap (Json.Decode.field "name" Json.Decode.string)
-                                |> andMap (Json.Decode.field "description" Json.Decode.string)
+                            -- if we have a system field that is optional, it is just optional
+                            -- doesn't affect end user filling up forms, but form builder can delete it
+                            Json.Decode.succeed Optional
 
                         _ ->
                             Json.Decode.fail ("Unknown presence type: " ++ type_)
@@ -1431,6 +1390,14 @@ encodeFormFields formFields =
             (\formField ->
                 Json.Encode.object
                     ([ ( "label", Json.Encode.string formField.label )
+                     , ( "name"
+                       , case formField.name of
+                            Just name ->
+                                Json.Encode.string name
+
+                            Nothing ->
+                                Json.Encode.null
+                       )
                      , ( "presence", encodePresence formField.presence )
                      , ( "description", Json.Encode.string formField.description )
                      , ( "type", encodeInputField formField.type_ )
@@ -1452,6 +1419,7 @@ decodeFormField : Json.Decode.Decoder FormField
 decodeFormField =
     Json.Decode.succeed FormField
         |> andMap (Json.Decode.field "label" Json.Decode.string)
+        |> andMap (Json.Decode.Extra.optionalNullableField "name" Json.Decode.string)
         |> andMap (Json.Decode.field "presence" decodePresence)
         |> andMap (Json.Decode.field "description" Json.Decode.string)
         |> andMap (Json.Decode.field "type" decodeInputField)

--- a/tests/MainTest.elm
+++ b/tests/MainTest.elm
@@ -7,21 +7,6 @@ import Fuzz exposing (Fuzzer, string)
 import Json.Decode
 import Json.Encode
 import Main
-    exposing
-        ( Choice
-        , FormField
-        , InputField(..)
-        , Presence(..)
-        , ViewMode(..)
-        , allInputField
-        , decodeChoice
-        , decodeFormFields
-        , decodeShortTextTypeList
-        , encodeChoice
-        , encodeFormFields
-        , stringFromViewMode
-        , viewModeFromString
-        )
 import Test exposing (..)
 
 
@@ -36,15 +21,15 @@ suite =
                             |> Array.fromList
                 in
                 formFields
-                    |> encodeFormFields
+                    |> Main.encodeFormFields
                     |> Json.Encode.encode 0
-                    |> Json.Decode.decodeString decodeFormFields
+                    |> Json.Decode.decodeString Main.decodeFormFields
                     |> Expect.equal (Ok formFields)
         , Test.fuzz viewModeFuzzer "stringFromViewMode,viewModeFromString is reversible" <|
             \mode ->
                 mode
-                    |> stringFromViewMode
-                    |> viewModeFromString
+                    |> Main.stringFromViewMode
+                    |> Main.viewModeFromString
                     |> Expect.equal (Just mode)
         , test "decodeShortTextTypeList" <|
             \_ ->
@@ -56,7 +41,7 @@ suite =
                     { "Nric": { "type": "text", "pattern": "^[STGM][0-9]{7}[ABCDEFGHIZJ]$" } }
                 ]
                 """
-                    |> Json.Decode.decodeString decodeShortTextTypeList
+                    |> Json.Decode.decodeString Main.decodeShortTextTypeList
                     |> Expect.equal
                         (Ok
                             [ ( "Text", Dict.fromList [ ( "type", "text" ) ] )
@@ -65,13 +50,21 @@ suite =
                             , ( "Nric", Dict.fromList [ ( "pattern", "^[STGM][0-9]{7}[ABCDEFGHIZJ]$" ), ( "type", "text" ) ] )
                             ]
                         )
-        , Test.fuzz choiceStringFuzzer "choiceStringToChoice,choiceStringFromString is reversible" <|
-            \choice ->
-                choice
-                    |> encodeChoice
+
+        -- , Test.fuzz choiceStringFuzzer "choiceStringToChoice,choiceStringFromString is reversible" <|
+        --     \choice ->
+        --         choice
+        --             |> encodeChoice
+        --             |> Json.Encode.encode 0
+        --             |> Json.Decode.decodeString decodeChoice
+        --             |> Expect.equal (Ok choice)
+        , Test.fuzz pairOfFormFieldFuzzer "encode old FormField can be decoded with decodeFormField" <|
+            \{ oldField, newField } ->
+                oldField
+                    |> encodeFormField
                     |> Json.Encode.encode 0
-                    |> Json.Decode.decodeString decodeChoice
-                    |> Expect.equal (Ok choice)
+                    |> Json.Decode.decodeString Main.decodeFormField
+                    |> Expect.equal (Ok newField)
         ]
 
 
@@ -79,37 +72,37 @@ suite =
 --
 
 
-viewModeFuzzer : Fuzzer ViewMode
+viewModeFuzzer : Fuzzer Main.ViewMode
 viewModeFuzzer =
     Fuzz.oneOf
         [ -- Fuzz.constant (Editor { maybeAnimate = Nothing })
           -- we don't encode/decode `maybeHighlight` because it is transient value
           -- maybeHighlight is always Nothing
-          Fuzz.constant (Editor { maybeAnimate = Nothing })
-        , Fuzz.constant Preview
-        , Fuzz.constant CollectData
+          Fuzz.constant (Main.Editor { maybeAnimate = Nothing })
+        , Fuzz.constant Main.Preview
+        , Fuzz.constant Main.CollectData
         ]
 
 
-inputFieldFuzzer : Fuzzer InputField
+inputFieldFuzzer : Fuzzer Main.InputField
 inputFieldFuzzer =
-    allInputField
+    Main.allInputField
         |> List.map Fuzz.constant
         |> Fuzz.oneOf
 
 
-presenceFuzzer : Fuzzer Presence
+presenceFuzzer : Fuzzer Main.Presence
 presenceFuzzer =
     Fuzz.oneOf
-        [ Fuzz.constant Required
-        , Fuzz.constant Optional
-        , Fuzz.constant System
+        [ Fuzz.constant Main.Required
+        , Fuzz.constant Main.Optional
+        , Fuzz.constant Main.System
         ]
 
 
-fuzzFormField : Fuzzer FormField
+fuzzFormField : Fuzzer Main.FormField
 fuzzFormField =
-    Fuzz.map5 FormField
+    Fuzz.map5 Main.FormField
         string
         (Fuzz.maybe string)
         presenceFuzzer
@@ -117,12 +110,176 @@ fuzzFormField =
         inputFieldFuzzer
 
 
-choiceStringFuzzer : Fuzzer Choice
+choiceStringFuzzer : Fuzzer Main.Choice
 choiceStringFuzzer =
     Fuzz.oneOf
-        [ Fuzz.map2 Choice
+        [ Fuzz.map2 Main.Choice
             Fuzz.string
             Fuzz.string
         , Fuzz.string
-            |> Fuzz.map (\s -> Choice s s)
+            |> Fuzz.map (\s -> Main.Choice s s)
         ]
+
+
+
+-- Backward Compatible Types
+
+
+pairOfFormFieldFuzzer : Fuzzer { oldField : FormField, newField : Main.FormField }
+pairOfFormFieldFuzzer =
+    oldFormFieldFuzzer
+        |> Fuzz.map
+            (\oldField ->
+                { oldField = oldField
+                , newField = newFieldFromOldField oldField
+                }
+            )
+
+
+oldPresenceFuzzer : Fuzzer Presence
+oldPresenceFuzzer =
+    Fuzz.oneOf
+        [ Fuzz.constant Required
+        , Fuzz.constant Optional
+        , Fuzz.map2 (\name description -> System { name = name, description = description })
+            string
+            string
+        , Fuzz.map2 (\name description -> SystemRequired { name = name, description = description })
+            string
+            string
+        , Fuzz.map2 (\name description -> SystemOptional { name = name, description = description })
+            string
+            string
+        ]
+
+
+oldFormFieldFuzzer : Fuzzer FormField
+oldFormFieldFuzzer =
+    Fuzz.map4 FormField
+        string
+        oldPresenceFuzzer
+        string
+        inputFieldFuzzer
+
+
+newFieldFromOldField : FormField -> Main.FormField
+newFieldFromOldField oldField =
+    let
+        newPresence =
+            case oldField.presence of
+                Required ->
+                    Main.Required
+
+                Optional ->
+                    Main.Optional
+
+                System _ ->
+                    Main.System
+
+                SystemRequired _ ->
+                    Main.System
+
+                SystemOptional _ ->
+                    Main.Optional
+
+        maybeName =
+            case oldField.presence of
+                System { name } ->
+                    Just name
+
+                SystemRequired { name } ->
+                    Just name
+
+                SystemOptional { name } ->
+                    Just name
+
+                Required ->
+                    Nothing
+
+                Optional ->
+                    Nothing
+
+        maybeDescription =
+            case oldField.presence of
+                System { description } ->
+                    Just description
+
+                SystemRequired { description } ->
+                    Just description
+
+                SystemOptional { description } ->
+                    Just description
+
+                _ ->
+                    Nothing
+    in
+    { label = oldField.label
+    , name = maybeName
+    , presence = newPresence
+    , description = Maybe.withDefault oldField.description maybeDescription
+    , type_ = oldField.type_
+    }
+
+
+type alias NameDescription =
+    { name : String, description : String }
+
+
+type Presence
+    = Required
+    | Optional
+    | System NameDescription
+    | SystemRequired NameDescription
+    | SystemOptional NameDescription
+
+
+encodePresence : Presence -> Json.Encode.Value
+encodePresence presence =
+    case presence of
+        Required ->
+            Json.Encode.string "Required"
+
+        Optional ->
+            Json.Encode.string "Optional"
+
+        System sys ->
+            Json.Encode.object
+                [ ( "type", Json.Encode.string "System" )
+                , ( "name", Json.Encode.string sys.name )
+                , ( "description", Json.Encode.string sys.description )
+                ]
+
+        SystemRequired sys ->
+            Json.Encode.object
+                [ ( "type", Json.Encode.string "SystemRequired" )
+                , ( "name", Json.Encode.string sys.name )
+                , ( "description", Json.Encode.string sys.description )
+                ]
+
+        SystemOptional sys ->
+            Json.Encode.object
+                [ ( "type", Json.Encode.string "SystemOptional" )
+                , ( "name", Json.Encode.string sys.name )
+                , ( "description", Json.Encode.string sys.description )
+                ]
+
+
+type alias FormField =
+    { label : String
+    , presence : Presence
+    , description : String
+    , type_ : Main.InputField
+    }
+
+
+encodeFormField : FormField -> Json.Encode.Value
+encodeFormField formField =
+    Json.Encode.object
+        ([ ( "label", Json.Encode.string formField.label )
+         , ( "presence", encodePresence formField.presence )
+         , ( "description", Json.Encode.string formField.description )
+         , ( "type", Main.encodeInputField formField.type_ )
+         ]
+            -- smaller output json than if we encoded `null` all the time
+            |> List.filter (\( _, v ) -> v /= Json.Encode.null)
+        )

--- a/tests/MainTest.elm
+++ b/tests/MainTest.elm
@@ -103,19 +103,15 @@ presenceFuzzer =
     Fuzz.oneOf
         [ Fuzz.constant Required
         , Fuzz.constant Optional
-        , Fuzz.map2 (\name description -> SystemRequired { name = name, description = description })
-            Fuzz.string
-            Fuzz.string
-        , Fuzz.map2 (\name description -> SystemOptional { name = name, description = description })
-            Fuzz.string
-            Fuzz.string
+        , Fuzz.constant System
         ]
 
 
 fuzzFormField : Fuzzer FormField
 fuzzFormField =
-    Fuzz.map4 FormField
+    Fuzz.map5 FormField
         string
+        (Fuzz.maybe string)
         presenceFuzzer
         string
         inputFieldFuzzer

--- a/tests/MainTest.elm
+++ b/tests/MainTest.elm
@@ -50,14 +50,13 @@ suite =
                             , ( "Nric", Dict.fromList [ ( "pattern", "^[STGM][0-9]{7}[ABCDEFGHIZJ]$" ), ( "type", "text" ) ] )
                             ]
                         )
-
-        -- , Test.fuzz choiceStringFuzzer "choiceStringToChoice,choiceStringFromString is reversible" <|
-        --     \choice ->
-        --         choice
-        --             |> encodeChoice
-        --             |> Json.Encode.encode 0
-        --             |> Json.Decode.decodeString decodeChoice
-        --             |> Expect.equal (Ok choice)
+        , Test.fuzz choiceStringFuzzer "choiceStringToChoice,choiceStringFromString is reversible" <|
+            \choice ->
+                choice
+                    |> Main.encodeChoice
+                    |> Json.Encode.encode 0
+                    |> Json.Decode.decodeString Main.decodeChoice
+                    |> Expect.equal (Ok choice)
         , Test.fuzz pairOfFormFieldFuzzer "encode old FormField can be decoded with decodeFormField" <|
             \{ oldField, newField } ->
                 oldField


### PR DESCRIPTION
While it may seem like there's 2x2 dimensions as implemented in #1
- is it a required field for end user to fill in? `Required | Optional` 
- is it a system field that form builder must provide? `System | NotSystem`

Actually `System + Optional` need not exist. If the system field is optional for end user to fill in, then the form builder should be allowed to remove it from the form.

The real problem was that non system fields uses the field label as field names; `System` field was the only way to specify a field `name`.

So this PR fixes that by allowing field names to be optionally provided via the json.





