### PR TITLE
Fix browser compatibility and drag-and-drop issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A lightweight, customizable form builder and renderer written in Elm. Create dyn
 - Responsive design
 - Two modes: Editor (for building forms) and CollectData (for end users)
 - JSON import/export of form definitions
+- Cross-browser compatibility:
+  - Tested on Chrome, Firefox, Safari, and Edge
+  - Consistent behavior for form controls across browsers
+  - Optimized dropdown handling for Edge on Windows
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ A lightweight, customizable form builder and renderer written in Elm. Create dyn
   - Tested on Chrome, Firefox, Safari, and Edge
   - Consistent behavior for form controls across browsers
   - Optimized dropdown handling for Edge on Windows
+  - Built-in protection against browser extensions:
+    - Grammarly is automatically disabled for form fields
+    - Support for disabling Google Translate and Dark Reader
 
 ## Tasks
 
@@ -45,7 +48,15 @@ See the [tasks](tasks/) directory for planned features and improvements. Each ta
    <link rel="stylesheet" href="./dist/tiny-form-fields.min.css">
    ```
 
-2. Initialize the form builder in your HTML:
+2. Add meta tags to prevent browser extensions from interfering with form fields:
+   ```html
+   <!-- Disable Google Translate -->
+   <meta name="google" content="notranslate">
+   <!-- Disable Dark Reader -->
+   <meta name="darkreader-lock">
+   ```
+
+3. Initialize the form builder in your HTML:
    ```html
    <!-- Editor mode -->
    <div id="editor"></div>

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -8629,6 +8629,19 @@ var $elm$html$Html$Attributes$tabindex = function (n) {
 		$elm$core$String$fromInt(n));
 };
 var $elm$html$Html$textarea = _VirtualDom_node('textarea');
+var $author$project$Main$textarea = F2(
+	function (attrs, children) {
+		return A2(
+			$elm$html$Html$textarea,
+			A2(
+				$elm$core$List$cons,
+				A2($elm$html$Html$Attributes$attribute, 'data-gramm_editor', 'false'),
+				A2(
+					$elm$core$List$cons,
+					A2($elm$html$Html$Attributes$attribute, 'data-enable-grammarly', 'false'),
+					attrs)),
+			children);
+	});
 var $author$project$Main$viewFormFieldOptionsPreview = F3(
 	function (config, fieldID, formField) {
 		var fieldName = $author$project$Main$fieldNameOf(formField);
@@ -8780,7 +8793,7 @@ var $author$project$Main$viewFormFieldOptionsPreview = F3(
 								A2($elm$core$Dict$get, fieldName, config.C)))
 						]));
 				return A2(
-					$elm$html$Html$textarea,
+					$author$project$Main$textarea,
 					_Utils_ap(
 						_List_fromArray(
 							[
@@ -9549,7 +9562,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								$elm$html$Html$text('Choices')
 							])),
 						A2(
-						$elm$html$Html$textarea,
+						$author$project$Main$textarea,
 						_List_fromArray(
 							[
 								$elm$html$Html$Attributes$id('choices-' + idSuffix),
@@ -9664,7 +9677,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								if (!result.$) {
 									var a = result.a;
 									return A2(
-										$elm$html$Html$textarea,
+										$author$project$Main$textarea,
 										_List_fromArray(
 											[
 												$elm$html$Html$Attributes$required(true),
@@ -9682,7 +9695,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								} else {
 									var err = result.a;
 									return A2(
-										$elm$html$Html$textarea,
+										$author$project$Main$textarea,
 										_List_fromArray(
 											[
 												$elm$html$Html$Attributes$required(true),

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -9101,6 +9101,10 @@ var $author$project$Main$renderFormField = F4(
 					[
 						$elm$html$Html$Attributes$class('tff-field-container'),
 						A2(
+						$elm$html$Html$Events$on,
+						'click',
+						$elm$json$Json$Decode$succeed($author$project$Main$DragEnd)),
+						A2(
 						$elm$html$Html$Events$preventDefaultOn,
 						'dragover',
 						A2($author$project$Main$dragOverDecoder, index, $elm$core$Maybe$Nothing))

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -7886,7 +7886,10 @@ var $author$project$Main$updateFormField = F5(
 					var _v12 = $elm$core$List$reverse(conditions);
 					if (_v12.b) {
 						var last = _v12.a;
-						return last;
+						return A2(
+							$author$project$Main$updateComparisonInCondition,
+							$author$project$Main$updateComparisonValue(''),
+							last);
 					} else {
 						return A2(
 							$author$project$Main$Field,
@@ -8266,6 +8269,7 @@ var $author$project$Main$stringFromViewMode = function (viewMode) {
 };
 var $elm$html$Html$Attributes$type_ = $elm$html$Html$Attributes$stringProperty('type');
 var $elm$html$Html$Attributes$value = $elm$html$Html$Attributes$stringProperty('value');
+var $author$project$Main$DragEnd = {$: 11};
 var $author$project$Main$NoOp = {$: 0};
 var $author$project$Main$SelectField = function (a) {
 	return {$: 8, a: a};
@@ -8407,7 +8411,6 @@ var $elm$html$Html$Events$preventDefaultOn = F2(
 			event,
 			$elm$virtual_dom$VirtualDom$MayPreventDefault(decoder));
 	});
-var $author$project$Main$DragEnd = {$: 11};
 var $author$project$Main$DragStart = function (a) {
 	return {$: 9, a: a};
 };
@@ -9193,11 +9196,7 @@ var $author$project$Main$renderFormField = F4(
 										$elm$html$Html$Events$on,
 										'dragstart',
 										$elm$json$Json$Decode$succeed(
-											$author$project$Main$DragStart(index))),
-										A2(
-										$elm$html$Html$Events$on,
-										'dragend',
-										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
+											$author$project$Main$DragStart(index)))
 									]),
 								_List_fromArray(
 									[
@@ -9278,11 +9277,7 @@ var $author$project$Main$viewAddQuestionsList = F2(
 												{aI: 0, aQ: 1}),
 											g: inputField,
 											l: _List_Nil
-										}))),
-								A2(
-								$elm$html$Html$Events$on,
-								'dragend',
-								$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
+										})))
 							]),
 						_List_fromArray(
 							[
@@ -10135,7 +10130,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 												]),
 											_List_fromArray(
 												[
-													$elm$html$Html$text(' - ')
+													$elm$html$Html$text(' -- Remove this condition -- ')
 												])),
 										A2(
 											$elm$core$List$map,
@@ -10317,7 +10312,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 												]),
 											_List_fromArray(
 												[
-													$elm$html$Html$text(' - ')
+													$elm$html$Html$text(' -- Remove this field logic -- ')
 												])),
 											A2(
 											$elm$html$Html$option,
@@ -10895,7 +10890,11 @@ var $author$project$Main$viewFormBuilder = F2(
 								$elm$html$Html$div,
 								_List_fromArray(
 									[
-										$elm$html$Html$Attributes$class('tff-fields-container')
+										$elm$html$Html$Attributes$class('tff-fields-container'),
+										A2(
+										$elm$html$Html$Events$on,
+										'drop',
+										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 									]),
 								A2(
 									$elm$core$List$indexedMap,

--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -7762,7 +7762,7 @@ var $author$project$Main$updateFormField = F5(
 						return formField;
 				}
 			case 10:
-				if (msg.b === '') {
+				if (msg.b === '\n') {
 					var ruleIndex = msg.a;
 					return _Utils_update(
 						formField,
@@ -7812,7 +7812,7 @@ var $author$project$Main$updateFormField = F5(
 							formField.l)
 					});
 			case 12:
-				if (msg.c === '') {
+				if (msg.c === '\n') {
 					var ruleIndex = msg.a;
 					var conditionIndex = msg.b;
 					return _Utils_update(
@@ -9196,7 +9196,11 @@ var $author$project$Main$renderFormField = F4(
 										$elm$html$Html$Events$on,
 										'dragstart',
 										$elm$json$Json$Decode$succeed(
-											$author$project$Main$DragStart(index)))
+											$author$project$Main$DragStart(index))),
+										A2(
+										$elm$html$Html$Events$on,
+										'dragend',
+										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 									]),
 								_List_fromArray(
 									[
@@ -9277,7 +9281,11 @@ var $author$project$Main$viewAddQuestionsList = F2(
 												{aI: 0, aQ: 1}),
 											g: inputField,
 											l: _List_Nil
-										})))
+										}))),
+								A2(
+								$elm$html$Html$Events$on,
+								'dragend',
+								$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 							]),
 						_List_fromArray(
 							[
@@ -10126,7 +10134,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 											$elm$html$Html$option,
 											_List_fromArray(
 												[
-													$elm$html$Html$Attributes$value('')
+													$elm$html$Html$Attributes$value('\n')
 												]),
 											_List_fromArray(
 												[
@@ -10308,7 +10316,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 											$elm$html$Html$option,
 											_List_fromArray(
 												[
-													$elm$html$Html$Attributes$value('')
+													$elm$html$Html$Attributes$value('\n')
 												]),
 											_List_fromArray(
 												[

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -7878,7 +7878,10 @@ var $author$project$Main$updateFormField = F5(
 					var _v12 = $elm$core$List$reverse(conditions);
 					if (_v12.b) {
 						var last = _v12.a;
-						return last;
+						return A2(
+							$author$project$Main$updateComparisonInCondition,
+							$author$project$Main$updateComparisonValue(''),
+							last);
 					} else {
 						return A2(
 							$author$project$Main$Field,
@@ -8258,6 +8261,7 @@ var $author$project$Main$stringFromViewMode = function (viewMode) {
 };
 var $elm$html$Html$Attributes$type_ = $elm$html$Html$Attributes$stringProperty('type');
 var $elm$html$Html$Attributes$value = $elm$html$Html$Attributes$stringProperty('value');
+var $author$project$Main$DragEnd = {$: 11};
 var $author$project$Main$NoOp = {$: 0};
 var $author$project$Main$SelectField = function (a) {
 	return {$: 8, a: a};
@@ -8399,7 +8403,6 @@ var $elm$html$Html$Events$preventDefaultOn = F2(
 			event,
 			$elm$virtual_dom$VirtualDom$MayPreventDefault(decoder));
 	});
-var $author$project$Main$DragEnd = {$: 11};
 var $author$project$Main$DragStart = function (a) {
 	return {$: 9, a: a};
 };
@@ -9185,11 +9188,7 @@ var $author$project$Main$renderFormField = F4(
 										$elm$html$Html$Events$on,
 										'dragstart',
 										$elm$json$Json$Decode$succeed(
-											$author$project$Main$DragStart(index))),
-										A2(
-										$elm$html$Html$Events$on,
-										'dragend',
-										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
+											$author$project$Main$DragStart(index)))
 									]),
 								_List_fromArray(
 									[
@@ -9270,11 +9269,7 @@ var $author$project$Main$viewAddQuestionsList = F2(
 												{aI: 0, aQ: 1}),
 											g: inputField,
 											l: _List_Nil
-										}))),
-								A2(
-								$elm$html$Html$Events$on,
-								'dragend',
-								$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
+										})))
 							]),
 						_List_fromArray(
 							[
@@ -10127,7 +10122,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 												]),
 											_List_fromArray(
 												[
-													$elm$html$Html$text(' - ')
+													$elm$html$Html$text(' -- Remove this condition -- ')
 												])),
 										A2(
 											$elm$core$List$map,
@@ -10309,7 +10304,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 												]),
 											_List_fromArray(
 												[
-													$elm$html$Html$text(' - ')
+													$elm$html$Html$text(' -- Remove this field logic -- ')
 												])),
 											A2(
 											$elm$html$Html$option,
@@ -10887,7 +10882,11 @@ var $author$project$Main$viewFormBuilder = F2(
 								$elm$html$Html$div,
 								_List_fromArray(
 									[
-										$elm$html$Html$Attributes$class('tff-fields-container')
+										$elm$html$Html$Attributes$class('tff-fields-container'),
+										A2(
+										$elm$html$Html$Events$on,
+										'drop',
+										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 									]),
 								A2(
 									$elm$core$List$indexedMap,

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -7754,7 +7754,7 @@ var $author$project$Main$updateFormField = F5(
 						return formField;
 				}
 			case 10:
-				if (msg.b === '') {
+				if (msg.b === '\n') {
 					var ruleIndex = msg.a;
 					return _Utils_update(
 						formField,
@@ -7804,7 +7804,7 @@ var $author$project$Main$updateFormField = F5(
 							formField.l)
 					});
 			case 12:
-				if (msg.c === '') {
+				if (msg.c === '\n') {
 					var ruleIndex = msg.a;
 					var conditionIndex = msg.b;
 					return _Utils_update(
@@ -9188,7 +9188,11 @@ var $author$project$Main$renderFormField = F4(
 										$elm$html$Html$Events$on,
 										'dragstart',
 										$elm$json$Json$Decode$succeed(
-											$author$project$Main$DragStart(index)))
+											$author$project$Main$DragStart(index))),
+										A2(
+										$elm$html$Html$Events$on,
+										'dragend',
+										$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 									]),
 								_List_fromArray(
 									[
@@ -9269,7 +9273,11 @@ var $author$project$Main$viewAddQuestionsList = F2(
 												{aI: 0, aQ: 1}),
 											g: inputField,
 											l: _List_Nil
-										})))
+										}))),
+								A2(
+								$elm$html$Html$Events$on,
+								'dragend',
+								$elm$json$Json$Decode$succeed($author$project$Main$DragEnd))
 							]),
 						_List_fromArray(
 							[
@@ -10118,7 +10126,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 											$elm$html$Html$option,
 											_List_fromArray(
 												[
-													$elm$html$Html$Attributes$value('')
+													$elm$html$Html$Attributes$value('\n')
 												]),
 											_List_fromArray(
 												[
@@ -10300,7 +10308,7 @@ var $author$project$Main$visibilityRuleSection = F4(
 											$elm$html$Html$option,
 											_List_fromArray(
 												[
-													$elm$html$Html$Attributes$value('')
+													$elm$html$Html$Attributes$value('\n')
 												]),
 											_List_fromArray(
 												[

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -8621,6 +8621,19 @@ var $elm$html$Html$Attributes$tabindex = function (n) {
 		$elm$core$String$fromInt(n));
 };
 var $elm$html$Html$textarea = _VirtualDom_node('textarea');
+var $author$project$Main$textarea = F2(
+	function (attrs, children) {
+		return A2(
+			$elm$html$Html$textarea,
+			A2(
+				$elm$core$List$cons,
+				A2($elm$html$Html$Attributes$attribute, 'data-gramm_editor', 'false'),
+				A2(
+					$elm$core$List$cons,
+					A2($elm$html$Html$Attributes$attribute, 'data-enable-grammarly', 'false'),
+					attrs)),
+			children);
+	});
 var $author$project$Main$viewFormFieldOptionsPreview = F3(
 	function (config, fieldID, formField) {
 		var fieldName = $author$project$Main$fieldNameOf(formField);
@@ -8772,7 +8785,7 @@ var $author$project$Main$viewFormFieldOptionsPreview = F3(
 								A2($elm$core$Dict$get, fieldName, config.C)))
 						]));
 				return A2(
-					$elm$html$Html$textarea,
+					$author$project$Main$textarea,
 					_Utils_ap(
 						_List_fromArray(
 							[
@@ -9541,7 +9554,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								$elm$html$Html$text('Choices')
 							])),
 						A2(
-						$elm$html$Html$textarea,
+						$author$project$Main$textarea,
 						_List_fromArray(
 							[
 								$elm$html$Html$Attributes$id('choices-' + idSuffix),
@@ -9656,7 +9669,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								if (!result.$) {
 									var a = result.a;
 									return A2(
-										$elm$html$Html$textarea,
+										$author$project$Main$textarea,
 										_List_fromArray(
 											[
 												$elm$html$Html$Attributes$required(true),
@@ -9674,7 +9687,7 @@ var $author$project$Main$viewFormFieldOptionsBuilder = F3(
 								} else {
 									var err = result.a;
 									return A2(
-										$elm$html$Html$textarea,
+										$author$project$Main$textarea,
 										_List_fromArray(
 											[
 												$elm$html$Html$Attributes$required(true),

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -9093,6 +9093,10 @@ var $author$project$Main$renderFormField = F4(
 					[
 						$elm$html$Html$Attributes$class('tff-field-container'),
 						A2(
+						$elm$html$Html$Events$on,
+						'click',
+						$elm$json$Json$Decode$succeed($author$project$Main$DragEnd)),
+						A2(
 						$elm$html$Html$Events$preventDefaultOn,
 						'dragover',
 						A2($author$project$Main$dragOverDecoder, index, $elm$core$Maybe$Nothing))

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- https://github.com/jinjor/elm-break-dom -->
+  <meta name="google" content="notranslate">
+  <meta name="darkreader-lock">
+  <!--  -->
+
   <title>Embed</title>
   <link rel="stylesheet" href="./dist/tiny-form-fields.min.css">
 </head>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1903,7 +1903,7 @@ visibilityRuleSection fieldIndex formFields ruleIndex visibilityRule =
                                     fieldName
                             )
                         ]
-                        (option [ value "" ] [ text " - " ]
+                        (option [ value "" ] [ text " -- Remove this condition -- " ]
                             :: List.map
                                 (\field ->
                                     let
@@ -1987,7 +1987,7 @@ visibilityRuleSection fieldIndex formFields ruleIndex visibilityRule =
                                 "HideWhen"
                         )
                     ]
-                    [ option [ value "" ] [ text " - " ]
+                    [ option [ value "" ] [ text " -- Remove this field logic -- " ]
                     , option [ selected (isShowWhen visibilityRule), value "ShowWhen" ] [ text "Show this question when" ]
                     , option [ selected (isHideWhen visibilityRule), value "HideWhen" ] [ text "Hide this question when" ]
                     ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -941,7 +941,7 @@ updateFormField msg fieldIndex string formFields formField =
                 ChooseMultiple _ ->
                     formField
 
-        OnVisibilityRuleTypeInput ruleIndex "" ->
+        OnVisibilityRuleTypeInput ruleIndex "\n" ->
             { formField
                 | visibilityRule =
                     formField.visibilityRule
@@ -979,7 +979,7 @@ updateFormField msg fieldIndex string formFields formField =
                         formField.visibilityRule
             }
 
-        OnVisibilityConditionFieldInput ruleIndex conditionIndex "" ->
+        OnVisibilityConditionFieldInput ruleIndex conditionIndex "\n" ->
             { formField
                 | visibilityRule =
                     updateVisibilityRuleAt ruleIndex
@@ -1903,7 +1903,7 @@ visibilityRuleSection fieldIndex formFields ruleIndex visibilityRule =
                                     fieldName
                             )
                         ]
-                        (option [ value "" ] [ text " -- Remove this condition -- " ]
+                        (option [ value "\n" ] [ text " -- Remove this condition -- " ]
                             :: List.map
                                 (\field ->
                                     let
@@ -1987,7 +1987,7 @@ visibilityRuleSection fieldIndex formFields ruleIndex visibilityRule =
                                 "HideWhen"
                         )
                     ]
-                    [ option [ value "" ] [ text " -- Remove this field logic -- " ]
+                    [ option [ value "\n" ] [ text " -- Remove this field logic -- " ]
                     , option [ selected (isShowWhen visibilityRule), value "ShowWhen" ] [ text "Show this question when" ]
                     , option [ selected (isHideWhen visibilityRule), value "HideWhen" ] [ text "Hide this question when" ]
                     ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -41,7 +41,7 @@ port module Main exposing
 import Array exposing (Array)
 import Browser
 import Dict exposing (Dict)
-import Html exposing (Html, button, div, h2, h3, input, label, option, pre, select, text, textarea, ul)
+import Html exposing (Html, button, div, h2, h3, input, label, option, pre, select, text, ul)
 import Html.Attributes as Attr exposing (attribute, checked, class, classList, disabled, for, id, maxlength, minlength, name, placeholder, readonly, required, selected, tabindex, title, type_, value)
 import Html.Events exposing (on, onCheck, onClick, onInput, preventDefaultOn, stopPropagationOn)
 import Json.Decode
@@ -2365,7 +2365,7 @@ viewFormFieldOptionsBuilder shortTextTypeList index formField =
                     \result ->
                         case result of
                             Ok a ->
-                                Html.textarea
+                                textarea
                                     [ required True
                                     , class "tff-text-field"
                                     , placeholder "Enter one suggestion per line"
@@ -2375,7 +2375,7 @@ viewFormFieldOptionsBuilder shortTextTypeList index formField =
                                     []
 
                             Err err ->
-                                Html.textarea
+                                textarea
                                     [ required True
                                     , class "tff-text-field"
                                     , placeholder "Enter one suggestion per line"
@@ -3459,3 +3459,13 @@ selectInputGroup { selectAttrs, options, inputAttrs, children } =
             , input (class "tff-selectinput-input" :: inputAttrs) children
             ]
         ]
+
+
+textarea : List (Html.Attribute msg) -> List (Html.Html msg) -> Html msg
+textarea attrs children =
+    Html.textarea
+        (Attr.attribute "data-gramm_editor" "false"
+            :: Attr.attribute "data-enable-grammarly" "false"
+            :: attrs
+        )
+        children

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1643,6 +1643,7 @@ renderFormField maybeAnimate model index maybeFormField =
         Nothing ->
             div
                 [ class "tff-field-container"
+                , on "click" (Json.Decode.succeed DragEnd)
                 , preventDefaultOn "dragover" (dragOverDecoder index Nothing)
                 ]
                 [ div [ class "tff-field-placeholder" ] [] ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1793,6 +1793,7 @@ viewFormBuilder maybeAnimate model =
             ]
             [ div
                 [ class "tff-fields-container"
+                , on "drop" (Json.Decode.succeed DragEnd)
 
                 -- , preventDefaultOn "drop" (Json.Decode.succeed ( Drop Nothing, True ))
                 ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1022,6 +1022,7 @@ updateFormField msg fieldIndex string formFields formField =
                     case List.reverse conditions of
                         last :: _ ->
                             last
+                                |> updateComparisonInCondition (updateComparisonValue "")
 
                         [] ->
                             Field (getPreviousFieldNameOrLabel fieldIndex formFields) (Equals "")

--- a/tasks/0003-TODO-hide-show-logic.md
+++ b/tasks/0003-TODO-hide-show-logic.md
@@ -94,6 +94,10 @@ Add support for conditional visibility where each field can specify when it shou
 
 ### Browser Compatibility
 - [x] Ensure compatibility with major browsers (Chrome, Firefox, Safari, Edge)
+- [x] Handle browser extensions that may interfere with form fields
+    - [x] Disable Grammarly in textareas
+    - [x] Add meta tags to disable Google Translate
+    - [x] Add meta tag to disable Dark Reader
 
 ### Documentation & Testing
 - [ ] Update documentation with new feature

--- a/tasks/0003-TODO-hide-show-logic.md
+++ b/tasks/0003-TODO-hide-show-logic.md
@@ -84,10 +84,16 @@ Add support for conditional visibility where each field can specify when it shou
     - [x] Support Radio buttons field type  
     - [x] Support Checkboxes field type
     - [x] Support Single-line free text with contains comparison
+- [x] Fix browser compatibility issues
+    - [x] Fix empty value interpretation in dropdown options
+    - [x] Fix Edge browser compatibility on Windows
 - [ ] Handle dependent fields (fields that depend on hidden fields)
 - [ ] Skip validation for hidden required fields during form submission
 - [ ] Preserve values of hidden fields when they become visible again
 - [ ] Gracefully handle fields that become hidden during user input
+
+### Browser Compatibility
+- [x] Ensure compatibility with major browsers (Chrome, Firefox, Safari, Edge)
 
 ### Documentation & Testing
 - [ ] Update documentation with new feature


### PR DESCRIPTION
## Changes

### Browser Compatibility
- Fixed dropdown option value interpretation in various browsers
  - Changed empty value from `<option value="">` to `<option value="\n">` to ensure consistent behavior
  - Improved Edge browser compatibility on Windows
- Disabled third-party extensions that can interfere with form fields:
  - Added attributes to disable Grammarly in textareas
  - Added meta tags to disable Google Translate
  - Added meta tag to disable Dark Reader theme
  - Prevents these extensions from breaking form field behavior

### Drag-and-Drop Improvements
- Added `dragend` event handlers to both form field and field type elements
- Ensures drag state is properly reset when drag operation ends

### Test Improvements
- Added tests for visibility rule removal with newline value
- Added tests for visibility condition removal
- Reorganized test structure for better readability
- Added helper function `visibilityRuleCondition` for test clarity

### Documentation
- Updated README with cross-browser compatibility notes
- Updated task file to track browser compatibility fixes

## Testing
- All tests passing
- Manually verified dropdown behavior across browsers
- Verified drag-and-drop behavior with Edge on Windows
- Verified form fields work correctly with Grammarly, Google Translate, and Dark Reader disabled