### PR TITLE
Always remove `list` attribute from attributes dictionary; always used as `datalist : List String`

### DIFF
--- a/dist/tiny-form-fields.esm.js
+++ b/dist/tiny-form-fields.esm.js
@@ -5524,29 +5524,29 @@ var $elm$core$Dict$get = F2(
 			}
 		}
 	});
-var $elm$core$Basics$not = _Basics_not;
+var $elm$core$Basics$neq = _Utils_notEqual;
 var $elm$core$String$trim = _String_trim;
 var $author$project$Main$fromRawCustomElement = function (ele) {
 	return {
 		r: A2(
 			$elm$core$Dict$filter,
 			F2(
-				function (k, v) {
-					return !((k === 'list') && A2($elm$core$String$contains, '\n', v));
+				function (k, _v0) {
+					return k !== 'list';
 				}),
 			ele.r),
 		X: function () {
-			var _v0 = A2($elm$core$Dict$get, 'list', ele.r);
-			if (!_v0.$) {
-				var s = _v0.a;
-				var _v1 = A2(
+			var _v1 = A2($elm$core$Dict$get, 'list', ele.r);
+			if (!_v1.$) {
+				var s = _v1.a;
+				var _v2 = A2(
 					$elm$core$String$split,
 					'\n',
 					$elm$core$String$trim(s));
-				if (!_v1.b) {
+				if (!_v2.b) {
 					return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 				} else {
-					var list = _v1;
+					var list = _v2;
 					return $author$project$Main$AttributeGiven(
 						A2($elm$core$List$map, $author$project$Main$choiceFromString, list));
 				}
@@ -5557,15 +5557,15 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 		K: ele.K,
 		y: ele.y,
 		Z: function () {
-			var _v2 = A2($elm$core$Dict$get, 'maxlength', ele.r);
-			if (!_v2.$) {
-				if (_v2.a === '') {
+			var _v3 = A2($elm$core$Dict$get, 'maxlength', ele.r);
+			if (!_v3.$) {
+				if (_v3.a === '') {
 					return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 				} else {
-					var value = _v2.a;
-					var _v3 = $elm$core$String$toInt(value);
-					if (!_v3.$) {
-						var _int = _v3.a;
+					var value = _v3.a;
+					var _v4 = $elm$core$String$toInt(value);
+					if (!_v4.$) {
+						var _int = _v4.a;
 						return $author$project$Main$AttributeGiven(_int);
 					} else {
 						return $author$project$Main$AttributeInvalid(value);
@@ -5576,9 +5576,9 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 			}
 		}(),
 		aA: function () {
-			var _v4 = A2($elm$core$Dict$get, 'multiple', ele.r);
-			if (!_v4.$) {
-				switch (_v4.a) {
+			var _v5 = A2($elm$core$Dict$get, 'multiple', ele.r);
+			if (!_v5.$) {
+				switch (_v5.a) {
 					case '':
 						return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 					case 'true':
@@ -5586,7 +5586,7 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 					case 'false':
 						return $author$project$Main$AttributeGiven(false);
 					default:
-						var value = _v4.a;
+						var value = _v5.a;
 						return $author$project$Main$AttributeInvalid(value);
 				}
 			} else {
@@ -6154,7 +6154,6 @@ var $author$project$Main$encodePairsFromRawCustomElements = function (customElem
 			$elm$json$Json$Encode$string(customElement.y)),
 		_Utils_ap(inputTagAttrs, encodedAttrs));
 };
-var $elm$core$Basics$neq = _Utils_notEqual;
 var $author$project$Main$toRawCustomElement = function (ele) {
 	var addMultipleIfGiven = function (dict) {
 		var _v3 = ele.aA;
@@ -6600,6 +6599,7 @@ var $elm$core$List$member = F2(
 			xs);
 	});
 var $elm$core$Platform$Cmd$none = $elm$core$Platform$Cmd$batch(_List_Nil);
+var $elm$core$Basics$not = _Basics_not;
 var $author$project$Main$outgoing = _Platform_outgoingPort('outgoing', $elm$core$Basics$identity);
 var $author$project$Main$init = function (flags) {
 	var defaultShortTextTypeList = _List_fromArray(

--- a/dist/tiny-form-fields.js
+++ b/dist/tiny-form-fields.js
@@ -5516,29 +5516,29 @@ var $elm$core$Dict$get = F2(
 			}
 		}
 	});
-var $elm$core$Basics$not = _Basics_not;
+var $elm$core$Basics$neq = _Utils_notEqual;
 var $elm$core$String$trim = _String_trim;
 var $author$project$Main$fromRawCustomElement = function (ele) {
 	return {
 		r: A2(
 			$elm$core$Dict$filter,
 			F2(
-				function (k, v) {
-					return !((k === 'list') && A2($elm$core$String$contains, '\n', v));
+				function (k, _v0) {
+					return k !== 'list';
 				}),
 			ele.r),
 		X: function () {
-			var _v0 = A2($elm$core$Dict$get, 'list', ele.r);
-			if (!_v0.$) {
-				var s = _v0.a;
-				var _v1 = A2(
+			var _v1 = A2($elm$core$Dict$get, 'list', ele.r);
+			if (!_v1.$) {
+				var s = _v1.a;
+				var _v2 = A2(
 					$elm$core$String$split,
 					'\n',
 					$elm$core$String$trim(s));
-				if (!_v1.b) {
+				if (!_v2.b) {
 					return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 				} else {
-					var list = _v1;
+					var list = _v2;
 					return $author$project$Main$AttributeGiven(
 						A2($elm$core$List$map, $author$project$Main$choiceFromString, list));
 				}
@@ -5549,15 +5549,15 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 		K: ele.K,
 		y: ele.y,
 		Z: function () {
-			var _v2 = A2($elm$core$Dict$get, 'maxlength', ele.r);
-			if (!_v2.$) {
-				if (_v2.a === '') {
+			var _v3 = A2($elm$core$Dict$get, 'maxlength', ele.r);
+			if (!_v3.$) {
+				if (_v3.a === '') {
 					return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 				} else {
-					var value = _v2.a;
-					var _v3 = $elm$core$String$toInt(value);
-					if (!_v3.$) {
-						var _int = _v3.a;
+					var value = _v3.a;
+					var _v4 = $elm$core$String$toInt(value);
+					if (!_v4.$) {
+						var _int = _v4.a;
 						return $author$project$Main$AttributeGiven(_int);
 					} else {
 						return $author$project$Main$AttributeInvalid(value);
@@ -5568,9 +5568,9 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 			}
 		}(),
 		aA: function () {
-			var _v4 = A2($elm$core$Dict$get, 'multiple', ele.r);
-			if (!_v4.$) {
-				switch (_v4.a) {
+			var _v5 = A2($elm$core$Dict$get, 'multiple', ele.r);
+			if (!_v5.$) {
+				switch (_v5.a) {
 					case '':
 						return $author$project$Main$AttributeNotNeeded($elm$core$Maybe$Nothing);
 					case 'true':
@@ -5578,7 +5578,7 @@ var $author$project$Main$fromRawCustomElement = function (ele) {
 					case 'false':
 						return $author$project$Main$AttributeGiven(false);
 					default:
-						var value = _v4.a;
+						var value = _v5.a;
 						return $author$project$Main$AttributeInvalid(value);
 				}
 			} else {
@@ -6146,7 +6146,6 @@ var $author$project$Main$encodePairsFromRawCustomElements = function (customElem
 			$elm$json$Json$Encode$string(customElement.y)),
 		_Utils_ap(inputTagAttrs, encodedAttrs));
 };
-var $elm$core$Basics$neq = _Utils_notEqual;
 var $author$project$Main$toRawCustomElement = function (ele) {
 	var addMultipleIfGiven = function (dict) {
 		var _v3 = ele.aA;
@@ -6592,6 +6591,7 @@ var $elm$core$List$member = F2(
 			xs);
 	});
 var $elm$core$Platform$Cmd$none = $elm$core$Platform$Cmd$batch(_List_Nil);
+var $elm$core$Basics$not = _Basics_not;
 var $author$project$Main$outgoing = _Platform_outgoingPort('outgoing', $elm$core$Basics$identity);
 var $author$project$Main$init = function (flags) {
 	var defaultShortTextTypeList = _List_fromArray(

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2988,8 +2988,7 @@ fromRawCustomElement ele =
     , inputType = ele.inputType
     , attributes =
         ele.attributes
-            -- list="some-id" is not a `datalist : AttributeOptional (List Choice)`, we keep it in `.attributes`
-            |> Dict.filter (\k v -> not (k == "list" && String.contains "\n" v))
+            |> Dict.filter (\k _ -> k /= "list")
     , multiple =
         case Dict.get "multiple" ele.attributes of
             Just "" ->
@@ -3064,11 +3063,9 @@ toRawCustomElement ele =
                     Dict.insert "list" (String.join "\n" (List.map choiceToString list)) dict
 
                 AttributeInvalid _ ->
-                    -- see `fromRawCustomElement`, keep the "list":"someid" we keep in `.attributes`
                     dict
 
                 AttributeNotNeeded _ ->
-                    -- see `fromRawCustomElement`, keep the "list":"someid" we keep in `.attributes`
                     dict
     in
     { inputTag = ele.inputTag

--- a/tests/MainTest.elm
+++ b/tests/MainTest.elm
@@ -560,6 +560,51 @@ suite =
                             ()
                 ]
             ]
+        , describe "list attribute handling"
+            [ test "fromRawCustomElement removes list attribute" <|
+                \_ ->
+                    let
+                        ele =
+                            { rawCustomElement
+                                | attributes = Dict.fromList [ ( "list", "some-id" ) ]
+                            }
+                    in
+                    Main.fromRawCustomElement ele
+                        |> .attributes
+                        |> Dict.get "list"
+                        |> Expect.equal Nothing
+            , test "datalist is preserved when given" <|
+                \_ ->
+                    let
+                        ele =
+                            { rawCustomElement
+                                | attributes = Dict.fromList [ ( "list", "1\n2" ) ]
+                            }
+
+                        customElement =
+                            Main.fromRawCustomElement ele
+                    in
+                    case customElement.datalist of
+                        Main.AttributeGiven list ->
+                            list
+                                |> List.map .value
+                                |> Expect.equal [ "1", "2" ]
+
+                        _ ->
+                            Expect.fail "Expected AttributeGiven but got something else"
+            , test "datalist is not needed by default" <|
+                \_ ->
+                    let
+                        customElement =
+                            Main.fromRawCustomElement rawCustomElement
+                    in
+                    case customElement.datalist of
+                        Main.AttributeNotNeeded _ ->
+                            Expect.pass
+
+                        _ ->
+                            Expect.fail "Expected AttributeNotNeeded but got something else"
+            ]
         , describe "dragOverDecoder"
             [ test "decodes dragover event with formfield" <|
                 \_ ->
@@ -645,7 +690,6 @@ suite =
                               , attributes =
                                     Dict.fromList
                                         [ ( "type", "text" )
-                                        , ( "list", "someid" )
                                         ]
                               , multiple = Main.AttributeNotNeeded Nothing
                               , maxlength = Main.AttributeNotNeeded Nothing


### PR DESCRIPTION
This PR changes how we handle the `list` attribute in custom elements:

1. Always remove `list` attribute from the attributes dictionary in `fromRawCustomElement`
2. Simplify the logic by removing special handling of `list` attribute with/without newlines
3. Add dedicated test cases for list attribute handling:
   - Verify list attribute is removed from attributes
   - Verify datalist is preserved when given
   - Verify datalist is not needed by default
4. Update test data to match implementation

This change helps prevent confusion between [HTML's `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#list) and our custom datalist functionality.
- since `input[list]` is always used for `datalist`
- and we use list to manage `datalist`
- so they are mutually exclusive

This closes the incomplete fix at https://github.com/choonkeat/tiny-form-fields/pull/25