### PR TITLE
go: always generate maxLength for LongText type

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+    - name: Run test-json-compatibility
+      run: make test-json-compatibility
     - name: Run Playwright tests
       run: make -j2 run-ignore-error ping-run test-playwright stop-run
     - uses: actions/upload-artifact@v4

--- a/go/elm_json_test.go
+++ b/go/elm_json_test.go
@@ -143,7 +143,7 @@ func TestElmGeneratedJSON(t *testing.T) {
 			}
 
 			// Validate the form
-			err := ValidFormValues(toTinyFormFields(t, []byte(formFieldsJSON)), tc.values)
+			err := ValidFormValues([]byte(formFieldsJSON), tc.values)
 
 			if tc.shouldErr {
 				if err == nil {

--- a/go/validate.go
+++ b/go/validate.go
@@ -398,7 +398,7 @@ func (f *ChooseMultipleField) Validate(value []string, field TinyFormField) erro
 
 type LongTextField struct {
 	Type      string `json:"type"` // "LongText"
-	MaxLength int    `json:"maxLength,omitempty"`
+	MaxLength *int   `json:"maxLength"`
 }
 
 func (f *LongTextField) Validate(value []string, field TinyFormField) error {
@@ -415,8 +415,8 @@ func (f *LongTextField) Validate(value []string, field TinyFormField) error {
 	}
 	val := value[0]
 	// LongText can contain \r\n
-	if f.MaxLength > 0 && len(val) > f.MaxLength {
-		return fmt.Errorf("%w: %s exceeds max length of %d", ErrInvalidLength, fieldName, f.MaxLength)
+	if f.MaxLength != nil && len(val) > *f.MaxLength {
+		return fmt.Errorf("%w: %s exceeds max length of %d", ErrInvalidLength, fieldName, *f.MaxLength)
 	}
 	return nil
 }

--- a/go/validate_test.go
+++ b/go/validate_test.go
@@ -1,7 +1,6 @@
 package tinyformfields
 
 import (
-	"encoding/json"
 	"errors"
 	"net/url"
 	"testing"
@@ -231,7 +230,7 @@ func TestValidFormValues(t *testing.T) {
 		"question_15": {""},
 	}
 
-	err := ValidFormValues(toTinyFormFields(t, []byte(formFieldsJSON)), formValues)
+	err := ValidFormValues([]byte(formFieldsJSON), formValues)
 	if err != nil {
 		t.Errorf("Validation Error: %v", err)
 	}
@@ -272,7 +271,7 @@ func TestChoiceParsingAndValidation(t *testing.T) {
 		"question_2": {"Option1", "Option3"},
 	}
 
-	err := ValidFormValues(toTinyFormFields(t, []byte(formFieldsJSON)), formValues)
+	err := ValidFormValues([]byte(formFieldsJSON), formValues)
 	if err != nil {
 		t.Errorf("Validation Error: %v", err)
 	}
@@ -282,7 +281,7 @@ func TestChoiceParsingAndValidation(t *testing.T) {
 		"question_1": {"I might want to go!"},
 	}
 
-	err = ValidFormValues(toTinyFormFields(t, []byte(formFieldsJSON)), formValuesInvalid)
+	err = ValidFormValues([]byte(formFieldsJSON), formValuesInvalid)
 	expectedError := "invalid choice: question_1 has invalid value 'I might want to go!'. Valid choices are: [Yes Maybe No]"
 	if err == nil {
 		t.Errorf("Expected error but got nil")
@@ -616,7 +615,7 @@ func TestInvalidFormValues(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			err := ValidFormValues(toTinyFormFields(t, []byte(scenario.formFields)), scenario.formValues)
+			err := ValidFormValues([]byte(scenario.formFields), scenario.formValues)
 			if scenario.expectError == nil && err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			} else if scenario.expectError != nil {
@@ -1315,7 +1314,7 @@ func TestVisibilityRules(t *testing.T) {
 
 	for _, tt := range scenarios {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidFormValues(toTinyFormFields(t, []byte(tt.formFields)), tt.values)
+			err := ValidFormValues([]byte(tt.formFields), tt.values)
 			if tt.expectedError == nil {
 				if err != nil {
 					t.Errorf("Expected no error, got: %v", err)
@@ -1327,16 +1326,4 @@ func TestVisibilityRules(t *testing.T) {
 			}
 		})
 	}
-}
-
-func toTinyFormFields(t *testing.T, bytes []byte) []TinyFormField {
-	t.Helper()
-
-	var tff []TinyFormField
-	err := json.Unmarshal(bytes, &tff)
-	if err != nil {
-		t.Errorf("Validation Error: %v", err)
-	}
-
-	return tff
 }


### PR DESCRIPTION
update go struct to always generate `maxLength` for `LongText` as  it is a required attribute in tff
```
(2) Problem with the value at json[6].type:
    
        {
            "type": "LongText"
        }
    
    Expecting an OBJECT with a field named `maxLength`
```