### PR TITLE
Fix: Whitespace Validation Handling Between Elm and Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Tests
 on:
   push:
     branches: [ main ]
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
 jobs:
   test:
+    name: Run Playwright Tests
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -27,3 +28,20 @@ jobs:
         name: playwright-report
         path: playwright-report/
         retention-days: 30
+
+  go-test:
+    name: Run Go Tests
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: go
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.1"
+          cache: false  # No external dependencies, no go.sum to cache
+      - name: Run tests
+        working-directory: go
+        run: make test

--- a/go/validate.go
+++ b/go/validate.go
@@ -7,6 +7,7 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -196,32 +197,21 @@ type FieldType interface {
 	Validate(value []string, field TinyFormField) error
 }
 
-type Choice struct {
-	Value string
-	Label string
-}
-
 type ChoiceFilter struct {
 	Type      string `json:"type"`
 	FieldName string `json:"fieldName"`
 }
 
 // parseChoices parses the choices array, handling " | " delimiters.
-func parseChoices(choiceStrings []string) []Choice {
-	choices := make([]Choice, 0, len(choiceStrings))
+func parseChoices(choiceStrings []string) []string {
+	choices := make([]string, 0, len(choiceStrings))
 
 	for _, choiceStr := range choiceStrings {
 		parts := strings.SplitN(choiceStr, " | ", 2)
 		if len(parts) == 2 {
-			choices = append(choices, Choice{
-				Value: parts[0],
-				Label: parts[1],
-			})
+			choices = append(choices, strings.TrimSpace(parts[0]))
 		} else {
-			choices = append(choices, Choice{
-				Value: choiceStr,
-				Label: choiceStr,
-			})
+			choices = append(choices, strings.TrimSpace(choiceStr))
 		}
 	}
 	return choices
@@ -265,17 +255,11 @@ func (f *DropdownField) Validate(value []string, field TinyFormField) error {
 	parsedChoices := parseChoices(f.Choices)
 
 	// Check that val is one of the allowed values
-	for _, choice := range parsedChoices {
-		if val == choice.Value {
-			return nil // valid
-		}
+	if slices.Index(parsedChoices, val) == -1 {
+		return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, parsedChoices)
 	}
-	// Collect valid values
-	validValues := make([]string, len(parsedChoices))
-	for i, choice := range parsedChoices {
-		validValues[i] = choice.Value
-	}
-	return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, validValues)
+
+	return nil // valid
 }
 
 type ChooseOneField struct {
@@ -316,17 +300,11 @@ func (f *ChooseOneField) Validate(value []string, field TinyFormField) error {
 	parsedChoices := parseChoices(f.Choices)
 
 	// Check that val is one of the allowed values
-	for _, choice := range parsedChoices {
-		if val == choice.Value {
-			return nil // valid
-		}
+	if slices.Index(parsedChoices, val) == -1 {
+		return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, parsedChoices)
 	}
-	// Collect valid values
-	validValues := make([]string, len(parsedChoices))
-	for i, choice := range parsedChoices {
-		validValues[i] = choice.Value
-	}
-	return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, validValues)
+
+	return nil
 }
 
 type ChooseMultipleField struct {
@@ -374,23 +352,10 @@ func (f *ChooseMultipleField) Validate(value []string, field TinyFormField) erro
 	// Parse choices
 	parsedChoices := parseChoices(f.Choices)
 
-	// Collect valid values
-	validValues := make([]string, len(parsedChoices))
-	for i, choice := range parsedChoices {
-		validValues[i] = choice.Value
-	}
-
 	// Check that each value is among the allowed values
 	for _, val := range value {
-		valid := false
-		for _, choice := range parsedChoices {
-			if val == choice.Value {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, validValues)
+		if slices.Index(parsedChoices, val) == -1 {
+			return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, parsedChoices)
 		}
 	}
 	return nil

--- a/go/validate.go
+++ b/go/validate.go
@@ -208,11 +208,10 @@ func parseChoices(choiceStrings []string) []string {
 
 	for _, choiceStr := range choiceStrings {
 		parts := strings.SplitN(choiceStr, " | ", 2)
-		if len(parts) == 2 {
-			choices = append(choices, strings.TrimSpace(parts[0]))
-		} else {
-			choices = append(choices, strings.TrimSpace(choiceStr))
+		if len(parts) == 0 {
+			continue
 		}
+		choices = append(choices, strings.TrimSpace(parts[0]))
 	}
 	return choices
 }

--- a/go/validate_test.go
+++ b/go/validate_test.go
@@ -338,6 +338,25 @@ func TestInvalidFormValues(t *testing.T) {
 			expectError: nil,
 		},
 		{
+			name: "Valid Choice with Value with Spaces",
+			formFields: `[
+			  {
+				"label": "Question 1",
+				"name": "question_1",
+				"presence": "Required",
+				"type": {
+				  "type": "Dropdown",
+				  "choices": [
+					  " Yes ",
+					  " No "
+				  ]
+				}
+			  }
+			]`,
+			formValues:  url.Values{"question_1": {"Yes"}},
+			expectError: nil,
+		},
+		{
 			name: "Invalid Choice in Dropdown",
 			formFields: `[
 			  {


### PR DESCRIPTION
## Issue Description

There was a validation mismatch between the Elm frontend and Go backend when handling choice values that contain leading/trailing whitespace. This caused form validation to fail even when users selected valid options.

## Root Cause

**Elm Side (Frontend):**

- The `choiceFromString` function in `src/Main.elm` automatically trims whitespace from choice values when parsing:

  ```elm
  choiceFromString s =
      case String.split choiceDelimiter s of
          [ value ] ->
              { value = String.trim value, label = value }  -- Trims whitespace
          [ value, label ] ->
              { value = String.trim value, label = label }  -- Trims whitespace
          -- ... etc
  ```

**Go Side (Backend):**

- The original `parseChoices` function in `go/validate.go` did **not** trim whitespace, causing validation mismatches
- When form data was submitted, the Go validator would receive trimmed values from the frontend but compare against untrimmed choice definitions

## Example Scenario

1. Form definition contains choices: `[" Yes ", " No "]` (with spaces)
2. Elm frontend displays these choices but internally stores trimmed values: `["Yes", "No"]`
3. User selects "Yes" → frontend sends `"Yes"` to backend
4. Go backend validates `"Yes"` against original choices `[" Yes ", " No "]`
5. **Validation fails** because `"Yes" ≠ " Yes "`

## Solution

Modified the `parseChoices` function in `go/validate.go` to:

1. **Trim whitespace** from choice values using `strings.TrimSpace()` (core fix)

Additionally, the implementation was refactored to:

1. **Simplify the data structure** by returning `[]string` instead of `[]Choice` struct (since labels weren't used)
2. **Use `slices.Index()`** for cleaner validation logic and eliminate redundant loops
3. **Align the happy path** to the left edge following Go best practices

### Changes Made

```go
// Before: parseChoices returned []Choice without trimming
func parseChoices(choiceStrings []string) []Choice {
    // ... returned Choice{Value: choiceStr, Label: choiceStr}
}

// After: parseChoices returns []string with trimmed values
func parseChoices(choiceStrings []string) []string {
    choices := make([]string, 0, len(choiceStrings))
    for _, choiceStr := range choiceStrings {
        parts := strings.SplitN(choiceStr, " | ", 2)
        if len(parts) == 2 {
            choices = append(choices, strings.TrimSpace(parts[0]))  // Now trims!
        } else {
            choices = append(choices, strings.TrimSpace(choiceStr)) // Now trims!
        }
    }
    return choices
}
```

### Validation Logic Improvement

The refactoring also improved code readability and eliminated redundant work on validation failures. Previously, the code performed two separate operations: first checking validity with a loop, then collecting all values into a new slice for error messages. The new approach with `slices.Index()` and direct use of `parsedChoices` eliminates the second loop and memory allocation, while also keeping the happy path (successful validation) left-aligned:

```go
// Before: Manual loop with nested happy path + collection on failure
for _, choice := range parsedChoices {
    if val == choice.Value {
        return nil // valid (nested inside loop)
    }
}
// Collect valid values for error message
validValues := make([]string, len(parsedChoices))
for i, choice := range parsedChoices {
    validValues[i] = choice.Value
}
return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", 
    ErrInvalidChoice, fieldName, val, validValues)

// After: Happy path left-aligned, error handling explicit
if slices.Index(parsedChoices, val) == -1 {
    return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", 
        ErrInvalidChoice, fieldName, val, parsedChoices)
}
return nil // valid (left-aligned)
```

## Test Coverage

Added test case to verify the fix:

```go
{
    name: "Valid Choice with Value with Spaces",
    formFields: `[{
        "label": "Question 1",
        "name": "question_1", 
        "presence": "Required",
        "type": {
            "type": "Dropdown",
            "choices": [" Yes ", " No "]  // Choices with spaces
        }
    }]`,
    formValues: url.Values{"question_1": {"Yes"}},  // Trimmed value
    expectError: nil,  // Should pass validation
}
```

## Impact

- **Fixed validation errors** for forms with choices containing whitespace
- **Improved consistency** between Elm frontend and Go backend choice handling
