### PR TITLE
Security/input tag sanitization and choose multiple dedup

### DIFF
--- a/go/validate.go
+++ b/go/validate.go
@@ -338,26 +338,45 @@ func (f *ChooseMultipleField) Validate(value []string, field TinyFormField) erro
 		return nil
 	}
 
+	// Count distinct submissions. A raw POST body can repeat the same value
+	// (e.g. "color=Red&color=Red&color=Red"), which would otherwise let a
+	// caller satisfy MinRequired with a single distinct choice or inflate
+	// the count past MaxAllowed inspection.
+	distinct := uniqueStrings(value)
+
 	// Check MinRequired constraint
-	if f.MinRequired != nil && len(value) < *f.MinRequired {
-		return fmt.Errorf("%w: %s requires at least %d choices, got %d", ErrInvalidFieldValue, fieldName, *f.MinRequired, len(value))
+	if f.MinRequired != nil && len(distinct) < *f.MinRequired {
+		return fmt.Errorf("%w: %s requires at least %d choices, got %d", ErrInvalidFieldValue, fieldName, *f.MinRequired, len(distinct))
 	}
 
 	// Check MaxAllowed constraint
-	if f.MaxAllowed != nil && len(value) > *f.MaxAllowed {
-		return fmt.Errorf("%w: %s allows at most %d choices, got %d", ErrInvalidFieldValue, fieldName, *f.MaxAllowed, len(value))
+	if f.MaxAllowed != nil && len(distinct) > *f.MaxAllowed {
+		return fmt.Errorf("%w: %s allows at most %d choices, got %d", ErrInvalidFieldValue, fieldName, *f.MaxAllowed, len(distinct))
 	}
 
 	// Parse choices
 	parsedChoices := parseChoices(f.Choices)
 
 	// Check that each value is among the allowed values
-	for _, val := range value {
+	for _, val := range distinct {
 		if slices.Index(parsedChoices, val) == -1 {
 			return fmt.Errorf("%w: %s has invalid value '%s'. Valid choices are: %v", ErrInvalidChoice, fieldName, val, parsedChoices)
 		}
 	}
 	return nil
+}
+
+func uniqueStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 type LongTextField struct {

--- a/go/validate_test.go
+++ b/go/validate_test.go
@@ -1969,3 +1969,112 @@ func TestCascadingVisibilityBugFix(t *testing.T) {
 		})
 	}
 }
+
+// A raw POST body can repeat the same name=value pair to inflate the
+// submitted count (e.g. "color=Red&color=Red&color=Red"). The validator
+// must count DISTINCT choices when checking MinRequired / MaxAllowed so
+// that duplicate submissions can't satisfy a "pick at least N" rule with
+// a single real selection.
+func TestChooseMultipleDedupsMinRequired(t *testing.T) {
+	formFields := `[
+		{
+			"name": "colors",
+			"presence": "Required",
+			"label": "Colors",
+			"type": {
+				"type": "ChooseMultiple",
+				"choices": ["Red", "Blue", "Green"],
+				"minRequired": 3
+			}
+		}
+	]`
+
+	cases := []struct {
+		name    string
+		values  url.Values
+		wantErr error
+	}{
+		{
+			name:    "three distinct choices pass",
+			values:  url.Values{"colors": []string{"Red", "Blue", "Green"}},
+			wantErr: nil,
+		},
+		{
+			name:    "three copies of the same choice fail (dedup enforces minRequired)",
+			values:  url.Values{"colors": []string{"Red", "Red", "Red"}},
+			wantErr: ErrInvalidFieldValue,
+		},
+		{
+			name:    "two distinct plus one duplicate still fails minRequired=3",
+			values:  url.Values{"colors": []string{"Red", "Red", "Blue"}},
+			wantErr: ErrInvalidFieldValue,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidFormValues([]byte(formFields), tc.values)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected error %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestChooseMultipleDedupsMaxAllowed(t *testing.T) {
+	formFields := `[
+		{
+			"name": "colors",
+			"presence": "Required",
+			"label": "Colors",
+			"type": {
+				"type": "ChooseMultiple",
+				"choices": ["Red", "Blue", "Green"],
+				"maxAllowed": 2
+			}
+		}
+	]`
+
+	cases := []struct {
+		name    string
+		values  url.Values
+		wantErr error
+	}{
+		{
+			name:    "two distinct choices pass",
+			values:  url.Values{"colors": []string{"Red", "Blue"}},
+			wantErr: nil,
+		},
+		{
+			name:    "three copies of one choice passes after dedup (one distinct)",
+			values:  url.Values{"colors": []string{"Red", "Red", "Red"}},
+			wantErr: nil,
+		},
+		{
+			name:    "three distinct choices still fail maxAllowed=2",
+			values:  url.Values{"colors": []string{"Red", "Blue", "Green"}},
+			wantErr: ErrInvalidFieldValue,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidFormValues([]byte(formFields), tc.values)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected error %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4066,6 +4066,56 @@ decodeVisibilityRule =
             )
 
 
+-- XSS defense. Elm's VirtualDom rewrites on*/formAction keys and blanks
+-- javascript:/data:text/html, values, but leaves the tag name and other
+-- attributes untouched. A form definition can reach both, so we normalize
+-- here: reject any inputTag that isn't the default "input" or a valid
+-- custom-element name (must contain a hyphen per the HTML spec; that alone
+-- rules out iframe/object/embed/meta/etc.), and drop attributes whose
+-- name or value can still produce script execution or boundary-loosening
+-- on the native tags we do allow.
+sanitizeInputTag : String -> String
+sanitizeInputTag tag =
+    let
+        lowered =
+            String.toLower tag
+
+        isValidCustomElementName =
+            String.contains "-" lowered
+                && String.all
+                    (\c ->
+                        Char.isAlphaNum c || c == '-' || c == '_' || c == '.'
+                    )
+                    lowered
+                && (String.left 1 lowered
+                        |> String.all Char.isLower
+                   )
+    in
+    if lowered == defaultInputTag || isValidCustomElementName then
+        lowered
+
+    else
+        defaultInputTag
+
+
+sanitizeAttributes : Dict String String -> Dict String String
+sanitizeAttributes =
+    let
+        disallowedKeys =
+            [ "srcdoc"
+            , "sandbox"
+            , "allow"
+            , "csp"
+            , "http-equiv"
+            , "background"
+            ]
+
+        keyAllowed key =
+            not (List.member (String.toLower key) disallowedKeys)
+    in
+    Dict.filter (\k _ -> keyAllowed k)
+
+
 decodeCustomElement : Json.Decode.Decoder CustomElement
 decodeCustomElement =
     Json.Decode.succeed RawCustomElement
@@ -4073,11 +4123,13 @@ decodeCustomElement =
         |> andMap
             (Json.Decode.Extra.optionalField "inputTag" Json.Decode.string
                 |> Json.Decode.map (Maybe.withDefault defaultInputTag)
+                |> Json.Decode.map sanitizeInputTag
             )
         |> andMap
             (Json.Decode.Extra.optionalField "attributes" (Json.Decode.keyValuePairs Json.Decode.string)
                 |> Json.Decode.map (Maybe.withDefault [])
                 |> Json.Decode.map Dict.fromList
+                |> Json.Decode.map sanitizeAttributes
             )
         |> Json.Decode.map fromRawCustomElement
 
@@ -4293,7 +4345,7 @@ decodeShortTextTypeList =
         decodeAttributes =
             -- backward compatible decoder for old json
             Json.Decode.dict Json.Decode.string
-                |> Json.Decode.map (\attributes -> ( defaultInputTag, attributes ))
+                |> Json.Decode.map (\attributes -> ( defaultInputTag, sanitizeAttributes attributes ))
 
         decodeInputTagAttributes : Json.Decode.Decoder ( String, Dict String String )
         decodeInputTagAttributes =
@@ -4301,10 +4353,12 @@ decodeShortTextTypeList =
                 |> andMap
                     (Json.Decode.Extra.optionalField "inputTag" Json.Decode.string
                         |> Json.Decode.map (Maybe.withDefault defaultInputTag)
+                        |> Json.Decode.map sanitizeInputTag
                     )
                 |> andMap
                     (Json.Decode.field "attributes" (Json.Decode.keyValuePairs Json.Decode.string)
                         |> Json.Decode.map Dict.fromList
+                        |> Json.Decode.map sanitizeAttributes
                     )
     in
     Json.Decode.list (Json.Decode.dict (Json.Decode.oneOf [ decodeInputTagAttributes, decodeAttributes ]))

--- a/tests/XssDefenseTest.elm
+++ b/tests/XssDefenseTest.elm
@@ -1,0 +1,134 @@
+module XssDefenseTest exposing (..)
+
+import Dict
+import Expect
+import Json.Decode
+import Main
+import Test exposing (Test, describe, test)
+
+
+decodeTag : String -> Result String String
+decodeTag raw =
+    raw
+        |> Json.Decode.decodeString Main.decodeCustomElement
+        |> Result.mapError Json.Decode.errorToString
+        |> Result.map .inputTag
+
+
+decodeAttrs : String -> Result String (Dict.Dict String String)
+decodeAttrs raw =
+    raw
+        |> Json.Decode.decodeString Main.decodeCustomElement
+        |> Result.mapError Json.Decode.errorToString
+        |> Result.map .attributes
+
+
+suite : Test
+suite =
+    describe "XSS defenses on decoded form definitions"
+        [ describe "sanitizeInputTag via decodeCustomElement"
+            [ test "default 'input' tag survives" <|
+                \_ ->
+                    decodeTag """{"inputType":"Text","attributes":{"type":"text"}}"""
+                        |> Expect.equal (Ok "input")
+            , test "explicit 'input' tag survives" <|
+                \_ ->
+                    decodeTag """{"inputType":"Text","inputTag":"input","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "hyphenated custom element is allowed" <|
+                \_ ->
+                    decodeTag """{"inputType":"Nric","inputTag":"validated-input","attributes":{}}"""
+                        |> Expect.equal (Ok "validated-input")
+            , test "iframe is rejected and falls back to input" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"iframe","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "IFRAME with mixed case is also rejected" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"IFrame","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "object tag is rejected" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"object","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "embed tag is rejected" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"embed","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "meta tag is rejected" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"meta","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "script tag is rejected (defense in depth even though Elm rewrites)" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"script","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "tag starting with dash is rejected (invalid custom element)" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"-foo","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            , test "tag with non-alphanumeric chars is rejected" <|
+                \_ ->
+                    decodeTag """{"inputType":"x","inputTag":"my!tag","attributes":{}}"""
+                        |> Expect.equal (Ok "input")
+            ]
+        , describe "sanitizeAttributes via decodeCustomElement"
+            [ test "srcdoc is dropped (primary XSS vector)" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","inputTag":"iframe","attributes":{"srcdoc":"<script>alert(1)</script>","type":"text"}}"""
+                        |> Expect.equal (Ok (Dict.fromList [ ( "type", "text" ) ]))
+            , test "sandbox is dropped" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"sandbox":"allow-scripts","type":"text"}}"""
+                        |> Expect.equal (Ok (Dict.fromList [ ( "type", "text" ) ]))
+            , test "allow is dropped" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"allow":"camera","type":"text"}}"""
+                        |> Expect.equal (Ok (Dict.fromList [ ( "type", "text" ) ]))
+            , test "http-equiv is dropped" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"http-equiv":"refresh","content":"0;url=http://x"}}"""
+                        |> Expect.equal (Ok (Dict.fromList [ ( "content", "0;url=http://x" ) ]))
+            , test "srcdoc dropped case-insensitively" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"SrcDoc":"<script>bad</script>"}}"""
+                        |> Expect.equal (Ok Dict.empty)
+            , test "benign attributes pass through unchanged" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"type":"email","pattern":"^.+@.+$","maxlength":"100","placeholder":"you@example.com"}}"""
+                        |> Expect.equal
+                            (Ok
+                                (Dict.fromList
+                                    [ ( "type", "email" )
+                                    , ( "pattern", "^.+@.+$" )
+                                    , ( "maxlength", "100" )
+                                    , ( "placeholder", "you@example.com" )
+                                    ]
+                                )
+                            )
+            , test "style passes through (not in denylist, legitimate customization)" <|
+                \_ ->
+                    decodeAttrs """{"inputType":"x","attributes":{"style":"color:red","type":"text"}}"""
+                        |> Expect.equal
+                            (Ok
+                                (Dict.fromList
+                                    [ ( "style", "color:red" )
+                                    , ( "type", "text" )
+                                    ]
+                                )
+                            )
+            ]
+        , describe "end-to-end: the iframe+srcdoc PoC from the vuln report"
+            [ test "iframe tag and srcdoc attribute are both neutralized" <|
+                \_ ->
+                    let
+                        poc =
+                            """{"inputType":"x","inputTag":"iframe","attributes":{"srcdoc":"<script>alert(document.domain)</script>","src":"x"}}"""
+                    in
+                    poc
+                        |> Json.Decode.decodeString Main.decodeCustomElement
+                        |> Result.mapError Json.Decode.errorToString
+                        |> Result.map (\ce -> ( ce.inputTag, Dict.get "srcdoc" ce.attributes ))
+                        |> Expect.equal (Ok ( "input", Nothing ))
+            ]
+        ]


### PR DESCRIPTION
## Summary

Two independent security hardenings found during a manual review of the form-definition decode path and the Go server-side validator.

### 1. Custom-element tag + attribute sanitization (XSS hardening)

A form definition loaded from an untrusted source (e.g. the demo's URL hash in index.html) could specify inputTag: "iframe" with attributes: { "srcdoc": "<script>…</script>" }. Elm's VirtualDom only rewrites on* / formAction attribute keys and only blanks values starting with javascript: or data:text/html,, so srcdoc slipped through both filters. The iframe runs its inline HTML in the embedder's origin, yielding same-origin script execution (cookies, CSRF, DOM takeover).

**Fix** (src/Main.elm): sanitize at decode time.

- sanitizeInputTag — accept only "input" (default) or a valid hyphenated custom-element name (per the HTML custom-elements spec). Anything else (iframe, object, embed, meta, script, <foo!>, etc.) silently falls back to "input".
- sanitizeAttributes — drop attribute keys srcdoc, sandbox, allow, csp, http-equiv, background (script-execution or iframe-boundary loosening). Case-insensitive.
- Applied in both decodeCustomElement and decodeInputTagAttributes.

**Impact of the change on existing usage**: no known legitimate use in this repo or the demo is affected. Native input and hyphenated custom elements like validated-input pass through unchanged. style is **not** in the denylist — inline styling continues to work.

**Tests**: tests/XssDefenseTest.elm — 19 cases covering tag allowlist (input, validated-input, iframe, IFrame, object, embed, meta, script, -foo, my!tag), attribute denylist (srcdoc, sandbox, allow, http-equiv, case-insensitive), benign pass-through (type/pattern/maxlength/placeholder/style), and end-to-end neutralization of the exact iframe+srcdoc PoC.

### 2. ChooseMultiple dedup in Go validator

ChooseMultipleField.Validate counted len(value) directly against MinRequired and MaxAllowed. A raw POST body can repeat the same name=value pair (colors=Red&colors=Red&colors=Red), which satisfied a "pick at least 3" rule with one real selection. Browsers don't submit checkboxes that way and the Elm frontend dedupes, so this only surfaces on hand-crafted HTTP requests — but the Go validator is the server-side backstop and shouldn't be fooled by it.

**Fix** (go/validate.go): new uniqueStrings helper; dedupe before evaluating MinRequired, MaxAllowed, and the per-value choice check. Behavior on well-formed (non-duplicate) submissions is unchanged.

**Tests** (go/validate_test.go):
- TestChooseMultipleDedupsMinRequired — 3 distinct passes; 3 copies of one fails minRequired: 3; 2 distinct + 1 duplicate also fails.
- TestChooseMultipleDedupsMaxAllowed — 2 distinct passes; 3 copies of one passes (one distinct); 3 distinct exceeds maxAllowed: 2.
